### PR TITLE
Ignore rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,3 +55,6 @@ Style/SymbolArray:
 
 Style/Lambda:
   Enabled: false
+
+Style/EmptyMethod:
+  Enabled: false

--- a/config/initializers/forecast_io.rb
+++ b/config/initializers/forecast_io.rb
@@ -1,3 +1,5 @@
+# rubocop:disable Style/MultilineIfModifier
 ForecastIO.configure do |c|
+  # rubocop:enable Style/MultilineIfModifier
   c.api_key = ENV['DARK_SKY_API_KEY'] || Rails.application.credentials.dark_sky[:api_key]
 end unless Rails.env.test?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,9 @@
 Rails.application.routes.draw do
+  # rubocop:disable Style/IfUnlessModifier
   if Rails.env.development?
     mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql"
   end
-
+  # rubocop:enable Style/IfUnlessModifier
   post "/graphql", to: "graphql#execute"
 
   root to: 'pages#index'


### PR DESCRIPTION
Disables three rubocop rules that we disagree with: Style/EmptyMethod, Style/MultilineIfModifier, Style/IfUnlessModifier