### PR TITLE
[fix] ignore docker related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ yarn-debug.log*
 .yarn-integrity
 
 .env*
+
+# Ignore docker related files
+/vendor
+/.cache
+/.yarnrc


### PR DESCRIPTION
When running with docker containers a lot of stuff is generated that we should ignore.