### PR TITLE
fix: allow null in location google cal response

### DIFF
--- a/app/graphql/types/location_type.rb
+++ b/app/graphql/types/location_type.rb
@@ -8,7 +8,7 @@ class Types::LocationType < Types::BaseObject
   field "city_name", String
   field "is_primary", Boolean, method: :primary?
   field "weather", Types::WeatherType
-  field "googleCal", Types::CalendarType, method: :google_cal
+  field "googleCal", Types::CalendarType, method: :google_cal, null: true
   field "wifi_name", String
   field "wifi_password", String
   field "bathroom_code", String

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -1991,13 +1991,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Calendar",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "Calendar",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null


### PR DESCRIPTION
The location will respond with a null google_cal object if the location's calendar_id column is NULL. This change allows null in the graphql type.