### PR TITLE
Switch to weather subscriptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,10 @@ gem "graphql", "~> 1.8.3"
 # github API
 gem 'github_webhook', '~> 1.1'
 
+# jobs
+gem 'sidekiq'
+gem 'sidekiq-repeat'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,8 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.0)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (1.2.0)
@@ -75,6 +77,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
+    connection_pool (2.2.2)
     crass (1.0.4)
     declarative (0.0.10)
     declarative-option (0.1.0)
@@ -120,6 +123,7 @@ GEM
       sprockets-rails
     graphql (1.8.6)
     hashie (3.5.7)
+    hitimes (1.3.0)
     httpclient (2.8.3)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
@@ -127,6 +131,7 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    json (2.1.0)
     jwt (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -160,6 +165,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     os (0.9.6)
     parallel (1.12.1)
+    parse-cron (0.1.4)
     parser (2.5.1.0)
       ast (~> 2.4.0)
     pg (1.1.3)
@@ -201,6 +207,10 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redis (4.0.1)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
+    redlock (0.2.2)
+      redis (>= 3.0.0, < 5.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -249,6 +259,16 @@ GEM
     selenium-webdriver (3.11.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
+    sidekiq (3.4.1)
+      celluloid (~> 0.16.0)
+      connection_pool (>= 2.1.1)
+      json
+      redis (>= 3.0.6)
+      redis-namespace (>= 1.3.1)
+    sidekiq-repeat (0.1.2)
+      parse-cron (~> 0.1)
+      redlock (~> 0, >= 0.1.1)
+      sidekiq (~> 3)
     signet (0.8.1)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -270,6 +290,8 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timers (4.0.4)
+      hitimes
     turbolinks (5.1.1)
       turbolinks-source (~> 5.1)
     turbolinks-source (5.1.0)
@@ -322,6 +344,8 @@ DEPENDENCIES
   rubocop
   sass-rails (~> 5.0)
   selenium-webdriver
+  sidekiq
+  sidekiq-repeat
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3

--- a/Procfile.development
+++ b/Procfile.development
@@ -1,2 +1,3 @@
 rails: bin/rails s -b 0.0.0.0 -p 5000
 webpack: bin/webpack-dev-server
+sidekiq: bundle exec sidekiq

--- a/app/graphql/types/subscription_type.rb
+++ b/app/graphql/types/subscription_type.rb
@@ -2,4 +2,12 @@ class Types::SubscriptionType < Types::BaseObject
   field :event_published, Types::EventType, description: "An event was published to the API"
 
   def event_published; end
+
+  field :weather_published, Types::WeatherType do
+    description "Latest weather data retrieved"
+    argument :latitude, Float, required: true
+    argument :longitude, Float, required: true
+  end
+
+  def weather_published(latitude:, longitude:); end
 end

--- a/app/javascript/components/widgets/weather/panel.jsx
+++ b/app/javascript/components/widgets/weather/panel.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
-import { path } from 'ramda';
+import { assocPath } from 'ramda';
 import styled from 'styled-components';
 import CurrentTemp from './current-temp';
 import HourlyTemps from './hourly-temps';
@@ -65,6 +65,8 @@ ErrorMessage.propTypes = {
 const getPrimaryLocationWeather = gql`
   {
     primaryLocation {
+      latitude
+      longitude
       ...SunriseSunsetLocation
       weather {
         ...CurrentTemp
@@ -84,9 +86,61 @@ const getPrimaryLocationWeather = gql`
   ${DailyWeather.fragments.weather}
 `;
 
+const subscribeWeatherPublished = gql`
+  subscription onWeatherPublished($latitude: Float!, $longitude: Float!) {
+    weatherPublished(latitude: $latitude, longitude: $longitude) {
+      ...CurrentTemp
+      ...HourlyWeather
+      ...MinutelyWeather
+      ...SunriseSunsetWeather
+      ...DailyWeather
+    }
+  }
+
+  ${CurrentTemp.fragments.weather}
+  ${HourlyTemps.fragments.weather}
+  ${MinutelyWeather.fragments.weather}
+  ${SunriseSunset.fragments.weather}
+  ${DailyWeather.fragments.weather}
+`;
+
+class SubscribedWeather extends React.Component {
+  componentDidMount() {
+    this.props.subscribeToPublishedEvents();
+  }
+
+  render() {
+    const { primaryLocation } = this.props;
+    const { weather } = primaryLocation;
+    return (
+      <Column>
+        <CenteredRow>
+          <TempText>
+            <CurrentTemp {...{ weather }} />
+          </TempText>
+          <HourlyTemps {...{ weather }} />
+        </CenteredRow>
+        <SummaryText>
+          <MinutelyWeather {...{ weather }} />
+        </SummaryText>
+        <SunriseSunset {...{ location: primaryLocation, weather }} />
+        <DailyWeather {...{ weather }} />
+        <Notice>Powered by Dark Sky</Notice>
+      </Column>
+    );
+  }
+}
+
+SubscribedWeather.propTypes = {
+  primaryLocation: PropTypes.shape({
+    weather: PropTypes.shape({}).isRequired,
+  }).isRequired,
+  subscribeToPublishedEvents: PropTypes.func.isRequired,
+};
+
 export default () => (
-  <Query query={getPrimaryLocationWeather} pollInterval={120000}>
-    {({ loading, error, data }) => {
+  <Query query={getPrimaryLocationWeather}>
+    {({ loading, error, data, subscribeToMore }) => {
       if (loading) {
         return <LoadingMessage />;
       }
@@ -95,23 +149,32 @@ export default () => (
         return <ErrorMessage message={error.message} />;
       }
 
-      const location = path(['primaryLocation'], data);
-      const weather = path(['primaryLocation', 'weather'], data);
       return (
-        <Column>
-          <CenteredRow>
-            <TempText>
-              <CurrentTemp {...{ weather }} />
-            </TempText>
-            <HourlyTemps {...{ weather }} />
-          </CenteredRow>
-          <SummaryText>
-            <MinutelyWeather {...{ weather }} />
-          </SummaryText>
-          <SunriseSunset {...{ location, weather }} />
-          <DailyWeather {...{ weather }} />
-          <Notice>Powered by Dark Sky</Notice>
-        </Column>
+        <SubscribedWeather
+          primaryLocation={data.primaryLocation}
+          subscribeToPublishedEvents={() =>
+            subscribeToMore({
+              document: subscribeWeatherPublished,
+              variables: {
+                latitude: data.primaryLocation.latitude,
+                longitude: data.primaryLocation.longitude,
+              },
+              updateQuery: (prev, { subscriptionData }) => {
+                if (!subscriptionData.data) {
+                  return prev;
+                }
+
+                const { weatherPublished } = subscriptionData.data;
+
+                return assocPath(
+                  ['primaryLocation', 'weather'],
+                  weatherPublished,
+                  prev,
+                );
+              },
+            })
+          }
+        />
       );
     }}
   </Query>

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -2588,6 +2588,51 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "weatherPublished",
+              "description": "Latest weather data retrieved",
+              "args": [
+                {
+                  "name": "latitude",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Float",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "longitude",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Float",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Weather",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,

--- a/app/lib/clients/darksky_client.rb
+++ b/app/lib/clients/darksky_client.rb
@@ -2,7 +2,7 @@ class Clients::DarkskyClient
   def self.forecast(latitude, longitude)
     key = "darksky-response-#{latitude}-#{longitude}"
 
-    Rails.cache.fetch(key, expires_in: 2.minutes) do
+    Rails.cache.fetch(key, expires_in: 5.minutes) do
       ForecastIO.forecast(latitude, longitude)
     end
   end

--- a/app/workers/weather_poller_worker.rb
+++ b/app/workers/weather_poller_worker.rb
@@ -1,0 +1,41 @@
+# Polls weather for subscribed locations
+class WeatherPollerWorker
+  include Sidekiq::Worker
+  include Sidekiq::Repeat::Repeatable
+
+  repeat { hourly.minute_of_hour(0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55) }
+
+  def perform
+    logger.info "Running weather poll"
+
+    locations.each do |location|
+      poll(location.latitude, location.longitude)
+    end
+  end
+
+  def subscriptions
+    Redis.new.pubsub("channels", "helios2_*:graphql-event::weatherPublished:*")
+  end
+
+  Location = Struct.new(:latitude, :longitude)
+
+  PARSE_LOCATION = /latitude:(?<latitude>.+):longitude:(?<longitude>.+)$/
+
+  def locations
+    subscriptions.map do |subscription|
+      captures = PARSE_LOCATION.match(subscription).named_captures
+      Location.new(*captures.values)
+    end.uniq
+  end
+
+  def poll(latitude, longitude)
+    logger.info "Polling #{latitude} #{longitude}"
+
+    data = Clients::DarkskyClient.forecast(latitude, longitude)
+    Helios2Schema.subscriptions.trigger(
+      "weatherPublished",
+      { latitude: latitude.to_f, longitude: longitude.to_f },
+      data
+    )
+  end
+end

--- a/spec/workers/weather_poller_worker_spec.rb
+++ b/spec/workers/weather_poller_worker_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+RSpec.describe WeatherPollerWorker, type: :worker do
+  before {
+    allow(ForecastIO).to receive(:forecast) { "" }
+    allow_any_instance_of(Redis).to(
+      receive(:pubsub) {
+        ["helios2_development:graphql-event::weatherPublished:latitude:41.823979:longitude:-71.412834"]
+      }
+    )
+  }
+
+  describe "a poller" do
+    it "will query uniq locations from redis " do
+      expect(WeatherPollerWorker.new.locations).to(
+        eq([WeatherPollerWorker::Location.new("41.823979", "-71.412834")])
+      )
+    end
+
+    it "will publish the darksky response when polling a location" do
+      expect(Helios2Schema.subscriptions).to(
+        receive(:trigger).with(
+          "weatherPublished",
+          { latitude: 41.823979, longitude: -71.412834 },
+          ""
+        )
+      )
+      WeatherPollerWorker.new.poll("41.823979", "-71.412834")
+    end
+
+    it "will perform a poll for every location" do
+      worker = WeatherPollerWorker.new
+      expect(worker).to(
+        receive(:poll).with("41.823979", "-71.412834")
+      )
+      worker.perform
+    end
+  end
+end


### PR DESCRIPTION
This PR switches the front end weather widget from polling the weather graphql endpoint to receive weather updates via a web socket subscription. A backend worker is added to run every 5 minutes to poll the locations that clients are currently subscribed to.

Caveats:
* Some of the graphql channel still uses class instance variables to store data. This should eventually be switched to redis.
* Poller interval is currently hardcoded to 5 minutes.