### PR TITLE
chore: add production Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+release: RAILS_ENV=production bundle exec rake db:migrate assets:precompile
+web: RAILS_ENV=production bundle exec rails server
+worker: RAILS_ENV=production bundle exec sidekiq


### PR DESCRIPTION
Heroku needs a Procfile to define the release process and worker dyno. Potential future consolidation of Procfile and Procfile.development