### PR TITLE
fix: configure sidekiq to use redis_url env

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,11 @@
+Sidekiq.configure_server do |config|
+  config.redis = Rails.application.config_for(:redis)
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = Rails.application.config_for(:redis)
+end
+
+Sidekiq::Repeat.configure do |config|
+  config.redlock_redis_instances = [Rails.application.config_for(:redis)['url']]
+end


### PR DESCRIPTION
Configures sidekiq and sidekiq-repeat to connect to redis using the REDIS_URL env variable (used in Heroku).