### PR TITLE
Align time to the rest of the row

### DIFF
--- a/app/javascript/components/time.jsx
+++ b/app/javascript/components/time.jsx
@@ -22,7 +22,9 @@ const TimeValue = styled(Row)`
   ${/* sc-sel */ HourMin} {
     ${({ isPrimary }) =>
       isPrimary
-        ? `font-size: ${fontSizes.xlarge}`
+        ? `font-size: ${fontSizes.xlarge};
+           position: relative;
+           top: 8px;`
         : `font-size: ${fontSizes.small}`};
   }
 


### PR DESCRIPTION
Not sure if this is the best solution.  I tried to add a xlarge line-height to the time, but that was still a few pixels higher than the rest of the row. 

![screen shot 2018-12-21 at 4 50 21 pm](https://user-images.githubusercontent.com/897528/50365017-9b1e2280-0540-11e9-9b1b-69f42aaecda4.png)
