### PR TITLE
fix: No need to take(ramda) widgets before mapping

### DIFF
--- a/app/javascript/components/carousel.jsx
+++ b/app/javascript/components/carousel.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { take } from 'ramda';
 import { spacing } from '../lib/theme';
 import { Widget } from './carousel-elements';
 import widgetShape from '../lib/widget-shape';
@@ -10,7 +9,7 @@ const WidgetContainer = styled.div`
 `;
 
 export const Carousel = ({ widgets, selectedWidget }) =>
-  take(widgets.length - 1, widgets).map((widget, index) => (
+  widgets.map((widget, index) => (
     // eslint-disable-next-line react/no-array-index-key
     <WidgetContainer key={index}>
       <Widget


### PR DESCRIPTION
widgets.length -1 was also causing the last widget in the array to
not be displayed