### PR TITLE
fix: reduce dark sky notice margin

### DIFF
--- a/app/javascript/components/widgets/weather/panel.jsx
+++ b/app/javascript/components/widgets/weather/panel.jsx
@@ -51,7 +51,7 @@ const SummaryText = styled(WhiteText)`
 
 const Notice = styled(GreySubText)`
   font-size: ${fontSizes.tiny};
-  margin-top: 120px;
+  margin-top: 80px;
   text-align: center;
   width: ${leftPanelWidth};
 `;


### PR DESCRIPTION
notice was breaking out of the view height and causing scroll bars

Before:
![Screenshot from 2019-05-10 15-28-03](https://user-images.githubusercontent.com/524850/57551995-7a603900-7338-11e9-8b39-73d889b21f99.png)

