### PR TITLE
Add Slack announcements 

### DIFF
--- a/app/assets/images/icons/icon-calendar.svg
+++ b/app/assets/images/icons/icon-calendar.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="20" viewBox="0 0 18 20">
+    <g fill="none" fill-rule="evenodd">
+        <path fill="#FFF" fill-rule="nonzero" d="M16 2h-1V0h-2v2H5V0H3v2H2a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2zM9 5a3 3 0 1 1 .002 6.002A3 3 0 0 1 9 5zm6 12H3v-.976C3 14.074 7 13 9 13s6 1.073 6 3.024V17z"/>
+        <path d="M-3-1h24v24H-3z"/>
+    </g>
+</svg>

--- a/app/controllers/web_hooks/slack_controller.rb
+++ b/app/controllers/web_hooks/slack_controller.rb
@@ -1,18 +1,5 @@
 class WebHooks::SlackController < ApplicationController
   protect_from_forgery with: :null_session
-
-  protected def slack_message(event_callback)
-    publish(Event.slack_messages.with_external_id(event_callback[:event_id]))
-  end
-
-  private def publish(event_scope)
-    event = event_scope.first_or_initialize
-    return unless event.new_record?
-
-    event.save!
-    Helios2Schema.subscriptions.trigger("eventPublished", {}, event)
-  end
-
   def create
     halt 403, "Invalid Slack verification token: #{params[:token]}" if ENV['SLACK_VERIFICATION_TOKEN'] != params[:token]
     render plain: build_create_response
@@ -23,9 +10,54 @@ class WebHooks::SlackController < ApplicationController
     when 'url_verification'
       params[:challenge]
     when 'event_callback'
-      "Add Slack message event to db #{slack_message(params)}" if params[:event][:type] == 'message'
+      slack_event(params, params[:event][:type])
     else
       "Error"
     end
+  end
+
+  protected def slack_event(event_callback, type)
+    if type == 'message'
+      "Add Slack message to db #{publish_event(Event.slack_messages.with_external_id(event_callback[:event_id]))}"
+    elsif type == 'app_mention'
+      "Add Slack announcement to db #{publish_announcement(event_callback)}"
+    else 'Error'
+    end
+  end
+
+  private def publish_event(event_scope)
+    event = event_scope.first_or_initialize
+    return unless event.new_record?
+
+    event.save!
+    Helios2Schema.subscriptions.trigger("eventPublished", {}, event)
+  end
+
+  private def publish_announcement(event_callback)
+    announcement = Announcement.create!(parse_announcement(event_callback))
+    Helios2Schema.subscriptions.trigger("announcementPublished", {}, announcement)
+  end
+
+  private def parse_announcement(event_callback)
+    # Ex: "guests: Welcome to Roy and Amanda from Under Armour on May 23rd 2019 at 11:00 am in Providence"
+    type, content = event_callback[:event][:text].split(/: /)
+
+    case type
+    when 'guests'
+      announcement = handle_guests_command(content)
+      announcement[:announcement_id] = event_callback[:event_id]
+      announcement
+    end
+  end
+
+  def handle_guests_command(content)
+    content = content.split(/ to | from | on | in /).map(&:strip)
+    fields = %i[message people company publish_on location_id]
+    announcement = Hash[fields.zip(content)]
+    announcement[:location] = Location.find_by(city_name: announcement[:location_id])
+    Time.use_zone(announcement[:location][:time_zone]) {
+      announcement[:publish_on] = Time.zone.parse(announcement[:publish_on])
+    }
+    announcement
   end
 end

--- a/app/graphql/types/announcement_type.rb
+++ b/app/graphql/types/announcement_type.rb
@@ -1,0 +1,17 @@
+class Types::UTCDateTimeType < GraphQL::Schema::Scalar
+  def self.coerce_result(value, _ctx)
+    Time.at(value).utc
+  end
+end
+
+class Types::AnnouncementType < Types::BaseObject
+  graphql_name "Announcement"
+
+  field "id", ID
+  field "publish_on", Types::UTCDateTimeType
+  field "message", String
+  field "people", String
+  field "company", String
+  field "announcement_id", String
+  field "location_id", String
+end

--- a/app/graphql/types/location_type.rb
+++ b/app/graphql/types/location_type.rb
@@ -8,6 +8,7 @@ class Types::LocationType < Types::BaseObject
   field "city_name", String
   field "is_primary", Boolean, method: :primary?
   field "weather", Types::WeatherType
+  field "day_announcements", [Types::AnnouncementType]
   field "wifi_name", String
   field "wifi_password", String
   field "bathroom_code", String

--- a/app/graphql/types/subscription_type.rb
+++ b/app/graphql/types/subscription_type.rb
@@ -10,4 +10,8 @@ class Types::SubscriptionType < Types::BaseObject
   end
 
   def weather_published(latitude:, longitude:); end
+
+  field :announcement_published, Types::AnnouncementType, description: "An announcement was published"
+
+  def announcement_published; end
 end

--- a/app/javascript/components/widget-controller.jsx
+++ b/app/javascript/components/widget-controller.jsx
@@ -6,6 +6,7 @@ import SidePanel from './side-panel';
 import Twitter from './twitter';
 import Numbers from './widgets/numbers';
 import Weather from './widgets/weather';
+import Guests from './widgets/guests';
 import Live from './live-stream';
 import lockedIcon from '../../assets/images/locked.svg';
 import unlockedIcon from '../../assets/images/unlocked.svg';
@@ -46,6 +47,11 @@ const widgets = [
     panel: <Live />,
     text: 'MojoTech Boulder',
     children: 'Live.',
+  },
+  {
+    panel: <Guests.Panel />,
+    text: "Today's guests",
+    children: <Guests.Carousel />,
   },
 ];
 

--- a/app/javascript/components/widgets/guests/carousel.jsx
+++ b/app/javascript/components/widgets/guests/carousel.jsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Query } from 'react-apollo';
+import gql from 'graphql-tag';
+import { sortBy, prop, append, lensPath, set } from 'ramda';
+import styled from 'styled-components';
+import icon from '../../../../assets/images/icons/icon-calendar.svg';
+import { parseTime, isDateToday } from '../../../lib/datetime';
+import { LoadingMessage, DisconnectedMessage } from '../messages/message';
+
+const subscribeAnnouncementPublished = gql`
+  subscription onAnnouncementPublished {
+    announcementPublished {
+      message
+      people
+      company
+      publishOn
+      id
+    }
+  }
+`;
+
+const getPrimaryLocationAnnouncements = gql`
+  {
+    primaryLocation {
+      dayAnnouncements {
+        message
+        people
+        company
+        publishOn
+        id
+      }
+    }
+  }
+`;
+
+const AnnouncementTime = styled.div``;
+
+const AnnouncementTitle = styled.div``;
+
+const AnnouncementWrapper = styled.div`
+  display: flex;
+  height: 5vh;
+  padding: 1vh;
+`;
+
+const AnnouncementIcon = styled.div`
+  background: url(${icon});
+  width: 3vw;
+  background-repeat: no-repeat;
+`;
+
+class SubscribedAnnouncements extends React.Component {
+  componentDidMount() {
+    this.props.subscribeToPublishedAnnouncements();
+  }
+
+  render() {
+    const { dayAnnouncements } = this.props;
+
+    return (
+      <div>
+        {sortBy(prop('publishOn'), dayAnnouncements).map(item => (
+          <AnnouncementWrapper key={item.id}>
+            <AnnouncementIcon />
+            <div>
+              <AnnouncementTime>{parseTime(item.publishOn)}</AnnouncementTime>
+              <AnnouncementTitle>{item.people}</AnnouncementTitle>
+            </div>
+          </AnnouncementWrapper>
+        ))}
+      </div>
+    );
+  }
+}
+SubscribedAnnouncements.propTypes = {
+  dayAnnouncements: PropTypes.shape({
+    message: PropTypes.string.isRequired,
+    people: PropTypes.string.isRequired,
+    company: PropTypes.string.isRequired,
+    publishOn: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  subscribeToPublishedAnnouncements: PropTypes.func.isRequired,
+};
+
+const Guests = () => (
+  <Query query={getPrimaryLocationAnnouncements} pollInterval={3.6e6}>
+    {({ loading, error, data, subscribeToMore }) => {
+      if (loading) {
+        return <LoadingMessage />;
+      }
+
+      if (error) {
+        return <DisconnectedMessage />;
+      }
+
+      return (
+        <SubscribedAnnouncements
+          dayAnnouncements={data.primaryLocation.dayAnnouncements}
+          subscribeToPublishedAnnouncements={() =>
+            subscribeToMore({
+              document: subscribeAnnouncementPublished,
+              updateQuery: (prev, { subscriptionData }) => {
+                if (!subscriptionData.data) {
+                  return prev;
+                }
+                const { announcementPublished } = subscriptionData.data;
+
+                if (isDateToday(announcementPublished.publishOn)) {
+                  return set(
+                    lensPath(['primaryLocation', 'dayAnnouncements']),
+
+                    append(
+                      announcementPublished,
+                      prev.primaryLocation.dayAnnouncements,
+                    ),
+
+                    prev,
+                  );
+                }
+
+                return prev;
+              },
+            })
+          }
+        />
+      );
+    }}
+  </Query>
+);
+
+export default Guests;

--- a/app/javascript/components/widgets/guests/carousel.jsx
+++ b/app/javascript/components/widgets/guests/carousel.jsx
@@ -74,13 +74,15 @@ class SubscribedAnnouncements extends React.Component {
   }
 }
 SubscribedAnnouncements.propTypes = {
-  dayAnnouncements: PropTypes.shape({
-    message: PropTypes.string.isRequired,
-    people: PropTypes.string.isRequired,
-    company: PropTypes.string.isRequired,
-    publishOn: PropTypes.string.isRequired,
-    id: PropTypes.string.isRequired,
-  }).isRequired,
+  dayAnnouncements: PropTypes.arrayOf(
+    PropTypes.shape({
+      message: PropTypes.string.isRequired,
+      people: PropTypes.string.isRequired,
+      company: PropTypes.string.isRequired,
+      publishOn: PropTypes.string.isRequired,
+      id: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
   subscribeToPublishedAnnouncements: PropTypes.func.isRequired,
 };
 

--- a/app/javascript/components/widgets/guests/index.jsx
+++ b/app/javascript/components/widgets/guests/index.jsx
@@ -1,0 +1,7 @@
+import Carousel from './carousel';
+import Panel from './panel';
+
+export default {
+  Carousel,
+  Panel,
+};

--- a/app/javascript/components/widgets/guests/panel.jsx
+++ b/app/javascript/components/widgets/guests/panel.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const Panel = () => <div />;
+
+export default Panel;

--- a/app/javascript/components/widgets/guests/panel.jsx
+++ b/app/javascript/components/widgets/guests/panel.jsx
@@ -1,5 +1,90 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { Query } from 'react-apollo';
+import gql from 'graphql-tag';
+import styled from 'styled-components';
+import { parseDate } from '../../../lib/datetime';
+import { colors, weights, fontSizes, spacing } from '../../../lib/theme';
+import { LoadingMessage, DisconnectedMessage } from '../messages/message';
 
-export const Panel = () => <div />;
+const getPrimaryLocationAnnouncements = gql`
+  {
+    primaryLocation {
+      dayAnnouncements {
+        message
+        people
+        company
+        publishOn
+      }
+    }
+  }
+`;
 
-export default Panel;
+const AnnouncementWrapper = styled.div`
+  text-align: center;
+  padding-top: 25vh;
+  color: ${colors.white}
+  font-size: ${fontSizes.large};
+`;
+
+const AnnouncementMessage = styled.div`
+  width: 50vw;
+  opacity: 0.5;
+  font-style: italic;
+`;
+
+const AnnouncementTitle = styled.div`
+  width: 50vw;
+  font-weight: ${weights.bold};
+  padding-top: ${spacing.xxxl};
+  padding-bottom: ${spacing.xxxl};
+`;
+
+const AnnouncementDate = styled.div`
+  width: 50vw;
+  opacity: 0.5;
+  font-size: ${fontSizes.medium};
+  color: ${colors.white};
+`;
+
+const Announcement = ({
+  announcement: { message, people, company, publishOn },
+}) => (
+  <AnnouncementWrapper>
+    <AnnouncementMessage>{message}</AnnouncementMessage>
+    <AnnouncementTitle>
+      {people} from {company}
+    </AnnouncementTitle>
+    <AnnouncementDate>{parseDate(publishOn)}</AnnouncementDate>
+  </AnnouncementWrapper>
+);
+Announcement.propTypes = {
+  announcement: PropTypes.shape({
+    message: PropTypes.string.isRequired,
+    people: PropTypes.string.isRequired,
+    company: PropTypes.string.isRequired,
+    publishOn: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+const Guests = () => (
+  <Query query={getPrimaryLocationAnnouncements}>
+    {({ error, data }) => {
+      if (error) {
+        return <DisconnectedMessage />;
+      }
+
+      if (data.primaryLocation.dayAnnouncements.length > 0) {
+        return (
+          <Announcement
+            announcement={data.primaryLocation.dayAnnouncements[0]}
+          />
+        );
+      }
+      return <LoadingMessage />;
+    }}
+  </Query>
+);
+
+export default Guests;

--- a/app/javascript/lib/datetime.js
+++ b/app/javascript/lib/datetime.js
@@ -18,6 +18,9 @@ export const parseHour = datetime =>
 export const parseTime = datetime =>
   format(new Date(datetime), 'h:mm aa').toLowerCase();
 
+export const parseDate = datetime =>
+  format(new Date(datetime), 'EEEE, MMM dd, yyyy');
+
 export const timeDiffInMinutes = (date, other) =>
   differenceInMinutes(date, other);
 

--- a/app/javascript/lib/datetime.test.js
+++ b/app/javascript/lib/datetime.test.js
@@ -4,6 +4,7 @@ import {
   dateForTimezone,
   parseHour,
   parseTime,
+  parseDate,
   timeDiffInMinutes,
   isDateToday,
   isDateTomorrow,
@@ -44,6 +45,16 @@ describe('#parseTime', () => {
   it('parses the time in a datetime', () => {
     expect(parseTime(datetime)).toEqual('6:35 am');
     expect(parseTime(datetime)).toEqual('6:35 am');
+  });
+});
+
+describe('#parseDate', () => {
+  const datetime = utcToZonedTime(
+    new Date('2019-05-28T10:35:00.000Z'),
+    'America/New_York',
+  );
+  it('parses the date in a datetime', () => {
+    expect(parseDate(datetime)).toEqual('Tuesday, May 28, 2019');
   });
 });
 

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -37,6 +37,51 @@
           "description": null,
           "fields": [
             {
+              "name": "announcements",
+              "description": "MojoTech announcements",
+              "args": [
+                {
+                  "name": "today",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "locationCityName",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Announcement",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "events",
               "description": "MojoTech slack/github events",
               "args": [
@@ -67,37 +112,6 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "EventCollection",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "googleCal",
-              "description": "Google Calendar response",
-              "args": [
-                {
-                  "name": "calendarId",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Calendar",
                   "ofType": null
                 }
               },
@@ -1985,15 +1999,19 @@
               "deprecationReason": null
             },
             {
-              "name": "googleCal",
+              "name": "dayAnnouncements",
               "description": null,
               "args": [
 
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "Calendar",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Announcement",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -2162,11 +2180,11 @@
         },
         {
           "kind": "OBJECT",
-          "name": "Calendar",
+          "name": "Announcement",
           "description": null,
           "fields": [
             {
-              "name": "items",
+              "name": "announcementId",
               "description": null,
               "args": [
 
@@ -2175,35 +2193,32 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "CalendarEvent",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,
               "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
+            },
+            {
+              "name": "company",
+              "description": null,
+              "args": [
 
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "CalendarEvent",
-          "description": null,
-          "fields": [
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "id",
               "description": null,
@@ -2215,7 +2230,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "ID",
                   "ofType": null
                 }
               },
@@ -2223,25 +2238,7 @@
               "deprecationReason": null
             },
             {
-              "name": "start",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CalendarTime",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "summary",
+              "name": "locationId",
               "description": null,
               "args": [
 
@@ -2257,22 +2254,9 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "CalendarTime",
-          "description": null,
-          "fields": [
+            },
             {
-              "name": "dateTime",
+              "name": "message",
               "description": null,
               "args": [
 
@@ -2282,7 +2266,43 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "UnixDateTime",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "people",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "publishOn",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },
@@ -2571,6 +2591,24 @@
           "name": "Subscription",
           "description": null,
           "fields": [
+            {
+              "name": "announcementPublished",
+              "description": "An announcement was published",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Announcement",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "eventPublished",
               "description": "An event was published to the API",

--- a/app/lib/simulate.rb
+++ b/app/lib/simulate.rb
@@ -17,7 +17,11 @@ class Simulate
     Simulate.new('push-master.json.erb')
   end
 
-  def self.slack_event
+  def self.slack_message
     Simulate.new('slack-message.json.erb')
+  end
+
+  def self.slack_announcement
+    Simulate.new('slack-announcement.json.erb')
   end
 end

--- a/app/lib/simulate/slack-announcement.json.erb
+++ b/app/lib/simulate/slack-announcement.json.erb
@@ -1,0 +1,19 @@
+{
+    "token": "Sim-123456",
+    "team_id": "T061EG9R6",
+    "api_app_id": "A0MDYCDME",
+    "event": {
+        "type": "app_mention",
+        "user": "U061F7AUR",
+        "text": "guests: Welcome to Roy and Amanda from Amica on May 23 2019 at 9:30 pm in Providence",
+        "ts": "1515449438.000011",
+        "channel": "C0LAN2Q65",
+        "event_ts": "1515449438000011"
+    },
+    "type": "event_callback",
+    "event_id": "<%= @event_id %>",
+    "event_time": 1515449438000011,
+    "authed_users": [
+        "U0LAN0Z89"
+    ]
+}

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,0 +1,14 @@
+class Announcement < ApplicationRecord
+  validates :publish_on, presence: true
+  validates :people, presence: true
+  validates :announcement_id, presence: true
+
+  belongs_to :location, inverse_of: :announcements
+
+  scope :with_location, ->(location) { where(location: location) }
+  scope :happen_today, ->(time_zone) do
+    today = Time.now.in_time_zone(time_zone)
+    tomorrow = today + 24.hours
+    where(publish_on: today..tomorrow)
+  end
+end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -4,12 +4,18 @@ class Location < ApplicationRecord
   validates :city_name, presence: true, uniqueness: true
   validates :time_zone, presence: true
 
+  has_many :announcements, inverse_of: :location, dependent: :destroy
+
   def self.primary(city_name = ENV['PRIMARY_CITY_NAME'])
     find_by(city_name: city_name)
   end
 
   def weather
     Clients::DarkskyClient.forecast(latitude, longitude)
+  end
+
+  def day_announcements
+    announcements.happen_today(time_zone)
   end
 
   def primary?

--- a/db/migrate/20190517184255_create_announcements.rb
+++ b/db/migrate/20190517184255_create_announcements.rb
@@ -1,0 +1,13 @@
+class CreateAnnouncements < ActiveRecord::Migration[5.2]
+  def change
+    create_table :announcements do |t|
+      t.datetime :publish_on, null: false
+      t.string :message
+      t.string :people, null: false
+      t.string :company
+      t.string :announcement_id, null: false, unique: true
+      t.references :location, type: :string
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,6 +20,18 @@ ActiveRecord::Schema.define(version: 2019_05_31_061410) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "announcements", force: :cascade do |t|
+    t.datetime "publish_on", null: false
+    t.string "message"
+    t.string "people", null: false
+    t.string "company"
+    t.string "announcement_id", null: false
+    t.string "location_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_announcements_on_location_id"
+  end
+
   create_table "events", force: :cascade do |t|
     t.string "source"
     t.string "external_id"

--- a/lib/tasks/simulate.rake
+++ b/lib/tasks/simulate.rake
@@ -12,7 +12,12 @@ namespace :simulate do
 
   desc "Simulates a new message on Slack"
   task slack_message: :environment do
-    post_slack_event(render_new_slack_event_json)
+    post_slack_event(render_new_slack_message_json)
+  end
+
+  desc "Simulates a new announcement on Slack"
+  task slack_announcement: :environment do
+    post_slack_event(render_new_slack_announcement_json)
   end
 
   def disable_github_authentication
@@ -41,7 +46,7 @@ namespace :simulate do
       params: params,
       headers: { 'Content-Type': 'application/json' }
     )
-    puts "Slack message response: #{resp}"
+    puts "Slack event response: #{resp}"
   end
 
   def render_new_pull_request_json
@@ -54,8 +59,15 @@ namespace :simulate do
     Simulate.push.render(hashes: hashes)
   end
 
-  def render_new_slack_event_json
-    hash = SecureRandom.uuid
-    Simulate.slack_event.render(event_id: "Sim-#{hash}")
+  def render_new_slack_message_json
+    Simulate.slack_message.render(event_id: "Sim-#{generate_hash}")
+  end
+
+  def render_new_slack_announcement_json
+    Simulate.slack_announcement.render(event_id: "Sim-#{generate_hash}")
+  end
+
+  def generate_hash
+    SecureRandom.uuid
   end
 end


### PR DESCRIPTION
- Added another route in the controller to handle a message to the Slack bot like "guests: Welcome to Person 1 and Person 2 from Amica on May 23 2019 at 9:30 pm in Providence"
- Made a table in the database to store each announcement's message, people, company, date and time, and location 
- Added the graphql queries to get the announcements to display in real time on the side carousel and the panel