### PR TITLE
Convert datetime.js functions to use date-fns for date calculations

### DIFF
--- a/app/javascript/components/widgets/numbers/carousel.jsx
+++ b/app/javascript/components/widgets/numbers/carousel.jsx
@@ -4,7 +4,7 @@ import { Query } from 'react-apollo';
 import numeral from 'numeral';
 import { over, lensPath, inc } from 'ramda';
 import pluralize from 'pluralize';
-import { getMostRecentDay } from '../../../lib/datetime';
+import { getStartOfWeek } from '../../../lib/datetime';
 import { getEventCounts, subscribeEventPublished } from './queries';
 import { LoadingMessage, ErrorMessage } from '../messages/default-messages';
 
@@ -36,10 +36,7 @@ SubscribedEvents.propTypes = {
 };
 
 const Numbers = () => (
-  <Query
-    query={getEventCounts}
-    variables={{ after: getMostRecentDay('Monday') }}
-  >
+  <Query query={getEventCounts} variables={{ after: getStartOfWeek() }}>
     {({ loading, error, data, subscribeToMore }) => {
       if (loading) {
         return <LoadingMessage />;

--- a/app/javascript/components/widgets/numbers/falling-blocks.jsx
+++ b/app/javascript/components/widgets/numbers/falling-blocks.jsx
@@ -8,7 +8,7 @@ import { getEventCounts } from './queries';
 import githubPull from '../../../../assets/images/pr.png';
 import githubCommit from '../../../../assets/images/commit.png';
 import slackMessage from '../../../../assets/images/slack.png';
-import { getMostRecentDay } from '../../../lib/datetime';
+import { getStartOfWeek } from '../../../lib/datetime';
 import { withLocalMutation, withLocalState } from './ducks';
 
 const blockTypes = { githubPull, githubCommit, slackMessage };
@@ -212,7 +212,7 @@ class Scene extends React.Component {
 export default compose(
   withApollo,
   graphql(getEventCounts, {
-    options: { variables: { after: getMostRecentDay('Monday') } },
+    options: { variables: { after: getStartOfWeek() } },
   }),
   withLocalState,
   withLocalMutation,

--- a/app/javascript/components/widgets/numbers/panel.jsx
+++ b/app/javascript/components/widgets/numbers/panel.jsx
@@ -4,7 +4,7 @@ import { Query } from 'react-apollo';
 import numeral from 'numeral';
 import styled from 'styled-components';
 import pluralize from 'pluralize';
-import { getMostRecentDay } from '../../../lib/datetime';
+import { getStartOfWeek } from '../../../lib/datetime';
 import { LoadingMessage, DisconnectedMessage } from '../messages/message';
 import { colors, weights, fontSizes } from '../../../lib/theme';
 import FallingBlocks from './falling-blocks';
@@ -71,10 +71,7 @@ SubscribedEvents.propTypes = {
 };
 
 const Numbers = () => (
-  <Query
-    query={getEventCounts}
-    variables={{ after: getMostRecentDay('Monday') }}
-  >
+  <Query query={getEventCounts} variables={{ after: getStartOfWeek() }}>
     {({ loading, error, data }) => {
       if (loading) {
         return <LoadingMessage />;

--- a/app/javascript/lib/datetime.js
+++ b/app/javascript/lib/datetime.js
@@ -1,71 +1,36 @@
-export const timeForTimezone = timeZone =>
-  new Date().toLocaleString('en-US', {
-    timeZone,
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+import { format, isSameDay, differenceInMinutes, getDay } from 'date-fns';
+import { utcToZonedTime } from 'date-fns-tz';
 
-export const dateForTimezone = timeZone =>
-  new Date().toLocaleString('en-US', {
-    timeZone,
-    weekday: 'long',
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
+export const timeForTimezone = (timezone, date = new Date()) =>
+  format(utcToZonedTime(new Date(date), timezone), 'hh:mm aa');
 
-export const timeAndDateForTimezone = timezone =>
+export const dateForTimezone = (timezone, date = new Date()) =>
+  format(utcToZonedTime(new Date(date), timezone), 'EEEE, MMM dd, yyyy');
+
+export const timeAndDateForTimezone = (timezone, date = new Date()) =>
   new Date(
-    new Date().toLocaleString('en-US', {
-      timezone,
-    }),
+    format(utcToZonedTime(new Date(date), timezone), "yyyy-MM-dd'T'HH:mm:ss"),
   );
 
 export const parseHour = datetime =>
-  new Date(Date.parse(datetime))
-    .toLocaleString('en-US', {
-      hour: 'numeric',
-      hour12: true,
-    })
-    .split(' ')
-    .join('')
-    .toLowerCase();
+  format(new Date(datetime), 'haa').toLowerCase();
 
 export const parseTime = datetime =>
-  new Date(Date.parse(datetime))
-    .toLocaleString('en-US', {
-      hour: 'numeric',
-      hour12: true,
-      minute: 'numeric',
-    })
-    .toLowerCase();
+  format(new Date(datetime), 'h:mm aa').toLowerCase();
 
-export const timeDiffInMinutes = (date, other) => {
-  const difference = date.getTime() - other.getTime();
-  return Math.round(difference / 60000);
-};
+export const timeDiffInMinutes = (date, other) =>
+  differenceInMinutes(date, other);
 
-const parseDatetime = datetime => new Date(Date.parse(datetime));
+export const isDateToday = datetime =>
+  isSameDay(new Date(datetime), new Date());
 
-const isToday = datetime =>
-  parseDatetime(datetime).toDateString() === new Date().toDateString();
-
-const isTomorrow = datetime => {
-  const tomorrowDate = new Date();
-  tomorrowDate.setDate(new Date().getDate() + 1);
-  return parseDatetime(datetime).toDateString() === tomorrowDate.toDateString();
-};
+export const isDateTomorrow = datetime =>
+  isSameDay(new Date(datetime), new Date().setDate(new Date().getDate() + 1));
 
 export const parseDay = datetime => {
-  if (isToday(datetime)) {
-    return 'Today';
-  }
-  if (isTomorrow(datetime)) {
-    return 'Tomorrow';
-  }
-  return parseDatetime(datetime).toLocaleString('en-US', {
-    weekday: 'long',
-  });
+  if (isDateToday(datetime)) return 'Today';
+  if (isDateTomorrow(datetime)) return 'Tomorrow';
+  return format(new Date(datetime), 'EEEE');
 };
 
 export const getWeekday = day => {
@@ -81,10 +46,12 @@ export const getWeekday = day => {
   return weekDays[day];
 };
 
-export const getMostRecentDay = (day, today = new Date()) => {
-  const d = getWeekday(day);
-  const offset = (today.getDay() + 7 - d) % 7;
-  return new Date(today.setDate(today.getDate() - offset))
-    .toISOString()
-    .slice(0, 10);
-};
+export const getMostRecentDay = (day, today = new Date()) =>
+  format(
+    new Date(
+      today.setDate(
+        today.getDate() - ((getDay(today) + 7 - getWeekday(day)) % 7),
+      ),
+    ),
+    'yyyy-MM-dd',
+  );

--- a/app/javascript/lib/datetime.js
+++ b/app/javascript/lib/datetime.js
@@ -1,4 +1,4 @@
-import { format, isSameDay, differenceInMinutes, getDay } from 'date-fns';
+import { format, isSameDay, differenceInMinutes, startOfWeek } from 'date-fns';
 import { utcToZonedTime } from 'date-fns-tz';
 
 export const timeForTimezone = (timezone, date = new Date()) =>
@@ -33,25 +33,5 @@ export const parseDay = datetime => {
   return format(new Date(datetime), 'EEEE');
 };
 
-export const getWeekday = day => {
-  const weekDays = {
-    Sunday: 0,
-    Monday: 1,
-    Tuesday: 2,
-    Wednesday: 3,
-    Thursday: 4,
-    Friday: 5,
-    Saturday: 6,
-  };
-  return weekDays[day];
-};
-
-export const getMostRecentDay = (day, today = new Date()) =>
-  format(
-    new Date(
-      today.setDate(
-        today.getDate() - ((getDay(today) + 7 - getWeekday(day)) % 7),
-      ),
-    ),
-    'yyyy-MM-dd',
-  );
+export const getStartOfWeek = () =>
+  startOfWeek(new Date(), { weekStartsOn: 1 }).toUTCString();

--- a/app/javascript/lib/datetime.test.js
+++ b/app/javascript/lib/datetime.test.js
@@ -1,4 +1,105 @@
-import { getMostRecentDay } from './datetime';
+import { utcToZonedTime } from 'date-fns-tz';
+import {
+  timeForTimezone,
+  dateForTimezone,
+  parseHour,
+  parseTime,
+  timeDiffInMinutes,
+  isDateToday,
+  isDateTomorrow,
+  parseDay,
+  getMostRecentDay,
+} from './datetime';
+
+describe('#timeForTimezone', () => {
+  const timeZone = 'America/New_York';
+  const datetime = '2020-05-13T04:00:00.000Z';
+  it('returns the hour, minute and period for a timestamp in a specific timezone', () => {
+    expect(timeForTimezone(timeZone, datetime)).toEqual('12:00 AM');
+  });
+});
+
+describe('#dateForTimezone', () => {
+  const timeZone = 'America/New_York';
+  const datetime = '2020-04-13T04:00:00.000Z';
+  it('returns weekday, month, day, year for a timestamp in a specific timezone', () => {
+    expect(dateForTimezone(timeZone, datetime)).toEqual('Monday, Apr 13, 2020');
+  });
+});
+
+describe('#parseHour', () => {
+  const datetime = utcToZonedTime(
+    new Date('2019-05-28T10:00:00.000Z'),
+    'America/New_York',
+  );
+  it('parses the hour in a datetime', () => {
+    expect(parseHour(datetime)).toEqual('6am');
+  });
+});
+
+describe('#parseTime', () => {
+  const datetime = utcToZonedTime(
+    new Date('2019-05-28T10:35:00.000Z'),
+    'America/New_York',
+  );
+  it('parses the time in a datetime', () => {
+    expect(parseTime(datetime)).toEqual('6:35 am');
+    expect(parseTime(datetime)).toEqual('6:35 am');
+  });
+});
+
+describe('#timeDiffInMinutes', () => {
+  const date1 = new Date(2014, 6, 2, 12, 20, 0);
+  const date2 = new Date(2014, 6, 2, 12, 7, 59);
+  it('returns difference of two timestamps in minutes', () => {
+    expect(timeDiffInMinutes(date1, date2)).toEqual(12);
+  });
+});
+
+describe('#isDateToday', () => {
+  const today = new Date();
+  const tomorrow = new Date();
+  tomorrow.setDate(today.getDate() + 1);
+  it('returns true if the given date is today', () => {
+    expect(isDateToday(today)).toEqual(true);
+    expect(isDateToday(tomorrow)).toEqual(false);
+  });
+});
+
+describe('#isDateTomorrow', () => {
+  const today = new Date();
+  const tomorrow = new Date();
+  tomorrow.setDate(today.getDate() + 1);
+  it('returns true if the given date is tomorrow', () => {
+    expect(isDateTomorrow(today)).toEqual(false);
+    expect(isDateTomorrow(tomorrow)).toEqual(true);
+  });
+});
+
+describe('#parseDay', () => {
+  const weekdays = [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+  ];
+
+  const today = new Date();
+  const tomorrow = new Date();
+  tomorrow.setDate(today.getDate() + 1);
+  const afterTomorrow = new Date();
+  afterTomorrow.setDate(today.getDate() + 2);
+  const weekdayAfterTomorrow = weekdays[afterTomorrow.getDay()];
+
+  it('returns name of day for a given datetime', () => {
+    expect(parseDay(today)).toEqual('Today');
+    expect(parseDay(tomorrow)).toEqual('Tomorrow');
+    expect(parseDay(afterTomorrow)).toEqual(weekdayAfterTomorrow);
+  });
+});
 
 describe('#getMostRecentDay', () => {
   const today = new Date('Monday May 13, 2019');

--- a/app/javascript/lib/datetime.test.js
+++ b/app/javascript/lib/datetime.test.js
@@ -8,7 +8,6 @@ import {
   isDateToday,
   isDateTomorrow,
   parseDay,
-  getMostRecentDay,
 } from './datetime';
 
 describe('#timeForTimezone', () => {
@@ -98,15 +97,5 @@ describe('#parseDay', () => {
     expect(parseDay(today)).toEqual('Today');
     expect(parseDay(tomorrow)).toEqual('Tomorrow');
     expect(parseDay(afterTomorrow)).toEqual(weekdayAfterTomorrow);
-  });
-});
-
-describe('#getMostRecentDay', () => {
-  const today = new Date('Monday May 13, 2019');
-  it('gets most recent Monday if today is Monday', () => {
-    expect(getMostRecentDay('Monday', today)).toEqual('2019-05-13');
-  });
-  it('gets most recent Tuesday if today is Monday', () => {
-    expect(getMostRecentDay('Tuesday', today)).toEqual('2019-05-07');
   });
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "apollo-link-http": "^1.5.4",
     "apollo-utilities": "^1.0.16",
     "core-js": "2",
+    "date-fns": "^2.0.0-alpha.27",
+    "date-fns-tz": "^1.0.7",
     "graphql": "^0.13.2",
     "graphql-anywhere": "^4.1.15",
     "graphql-ruby-client": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3062,6 +3062,16 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+date-fns-tz@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.0.7.tgz#1c80f7592cca5da4fd2085132936dcc7fa9afecd"
+  integrity sha512-oNfi/3IxRfmysRIT+QJMbO/44Uj10nApAYJvlayTmNRFZG+JqdOJYXm1DWU65DNlG/ySbuQwpFkGIa3b2XFUVw==
+
+date-fns@^2.0.0-alpha.27:
+  version "2.0.0-alpha.27"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.0.0-alpha.27.tgz#5ecd4204ef0e7064264039570f6e8afbc014481c"
+  integrity sha512-cqfVLS+346P/Mpj2RpDrBv0P4p2zZhWWvfY5fuWrXNR/K38HaAGEkeOwb47hIpQP9Jr/TIxjZ2/sNMQwdXuGMg==
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"


### PR DESCRIPTION
- Wrote tests and implemented functions for datetime using date-fns
- The `timeAndDateForTimezone` and `getStartOfWeek` functions don't have tests because CircleCI runs tests at timezone UTC +0, which is different than the local timezone, and this became a problem when `new Date()` was called. I tried specifying timezone as a parameter but this was only ever used for testing purposes. 