### PR TITLE
feature: add event archiving task maintain:events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,9 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+# ActiveRecord extensions
+gem 'groupdate'
+
 gem "dotenv-rails", "~> 2.4.0"
 gem "forecast_io"
 gem "foreman", "~> 0.84"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
       railties
       sprockets-rails
     graphql (1.8.6)
+    groupdate (4.1.2)
+      activesupport (>= 4.2)
     hashie (3.5.7)
     hitimes (1.3.0)
     i18n (1.1.1)
@@ -303,6 +305,7 @@ DEPENDENCIES
   github_webhook (~> 1.1)
   graphiql-rails
   graphql (~> 1.8.3)
+  groupdate
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg

--- a/app/models/daily_event_summary.rb
+++ b/app/models/daily_event_summary.rb
@@ -1,0 +1,16 @@
+class DailyEventSummary < ApplicationRecord
+  def self.archive!(event_scope)
+    event_scope
+      .group(:source)
+      .group_by_day(:created_at, series: false)
+      .count
+      .each do |groups, count|
+      DailyEventSummary.create!(
+        source: groups[0],
+        day: groups[1],
+        count: count
+      )
+    end
+    event_scope.delete_all
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -13,4 +13,6 @@ class Event < ApplicationRecord
   scope :slack_messages, -> { where(source: :slack_message) }
 
   scope :with_external_id, ->(external_id) { where(external_id: external_id) }
+
+  scope :before_beginning_of_week, -> { where('created_at < ?', Time.zone.today.beginning_of_week) }
 end

--- a/db/migrate/20190531061410_create_daily_event_summaries.rb
+++ b/db/migrate/20190531061410_create_daily_event_summaries.rb
@@ -1,0 +1,10 @@
+class CreateDailyEventSummaries < ActiveRecord::Migration[5.2]
+  def change
+    create_table :daily_event_summaries do |t|
+      t.string :source, null: false
+      t.date :day, null: false
+      t.integer :count, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_21_194808) do
+ActiveRecord::Schema.define(version: 2019_05_31_061410) do
+
+  create_table "daily_event_summaries", force: :cascade do |t|
+    t.string "source", null: false
+    t.date "day", null: false
+    t.integer "count", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "events", force: :cascade do |t|
     t.string "source"

--- a/lib/tasks/maintain.rake
+++ b/lib/tasks/maintain.rake
@@ -1,0 +1,10 @@
+namespace :maintain do
+  desc "Archives events into daily_event_summaries"
+  task events: :environment do
+    Event.transaction do
+      scope = Event.before_beginning_of_week
+      puts "Archiving #{scope.count} events"
+      DailyEventSummary.archive!(scope)
+    end
+  end
+end

--- a/spec/models/daily_event_summary_spec.rb
+++ b/spec/models/daily_event_summary_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe DailyEventSummary, type: :model do
+  it "archives events into daily event summaries" do
+    Event.delete_all
+    DailyEventSummary.delete_all
+    Event.create!(source: 'github_pull', external_id: '1000')
+    Event.create!(source: 'github_pull', external_id: '1001')
+    Event.create!(source: 'github_pull', external_id: '1002')
+    Event.create!(source: 'github_commit', external_id: '100')
+
+    DailyEventSummary.archive!(Event.all)
+
+    expect(DailyEventSummary.count).to eq(2)
+    expect(Event.count).to eq(0)
+
+    pull = DailyEventSummary.where(source: 'github_pull').first
+    expect(pull).not_to be_nil
+    expect(pull.count).to eq(3)
+
+    commit = DailyEventSummary.where(source: 'github_commit').first
+    expect(commit).not_to be_nil
+    expect(commit.count).to eq(1)
+  end
+end


### PR DESCRIPTION
Heroku just notified me that we are using ~9,000 rows of the 10,000 row limit on the hobby-dev database. This adds a rake task to archive the events into daily summaries. The task is scoped to events older than the beginning of the week so it should not impact the current week's counts for mojotech by the numbers widget.