### PR TITLE
Support absolute js and jsx imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       webpack: {
-        config: 'config/webpacker.yml',
+        config: './config/webpack/webpack.config.custom.js',
       },
     },
   },

--- a/app/javascript/components/app.jsx
+++ b/app/javascript/components/app.jsx
@@ -11,8 +11,8 @@ import ActionCable from 'actioncable';
 import { getMainDefinition } from 'apollo-utilities';
 import ActionCableLink from 'graphql-ruby-client/subscriptions/ActionCableLink';
 import { persistCache } from 'apollo-cache-persist';
-import WidgetController from './widget-controller';
-import helioSchema from '../schema.json';
+import WidgetController from '@components/widget-controller';
+import helioSchema from '@javascript/schema.json';
 
 const cable = ActionCable.createConsumer('/cable');
 

--- a/app/javascript/components/bathroom.jsx
+++ b/app/javascript/components/bathroom.jsx
@@ -2,11 +2,8 @@ import React from 'react';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 import styled from 'styled-components';
-import { WhiteSubTitle, WhiteTitleLarge } from './typography';
-import {
-  LoadingMessage,
-  ErrorMessage,
-} from './widgets/messages/default-messages';
+import { WhiteSubTitle, WhiteTitleLarge } from '@components/typography';
+import { LoadingMessage, ErrorMessage } from '@messages/default-messages';
 
 const getBathroomCode = gql`
   {

--- a/app/javascript/components/date.jsx
+++ b/app/javascript/components/date.jsx
@@ -3,12 +3,9 @@ import PropTypes from 'prop-types';
 import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 import styled from 'styled-components';
-import { dateForTimezone } from 'lib/datetime';
-import { colors, fontSizes, spacing, fonts } from '../lib/theme';
-import {
-  LoadingMessage,
-  ErrorMessage,
-} from './widgets/messages/default-messages';
+import { dateForTimezone } from '@lib/datetime';
+import { colors, fontSizes, spacing, fonts } from '@lib/theme';
+import { LoadingMessage, ErrorMessage } from '@messages/default-messages';
 
 const getTimezone = gql`
   {

--- a/app/javascript/components/fixed-content.jsx
+++ b/app/javascript/components/fixed-content.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
-import Logo from './logo';
-import { SpacedRow, Row } from './row';
-import Date from './date';
-import TimeHero from './time-hero';
-import Wifi from './wifi';
-import Bathroom from './bathroom';
-import { spacing, colors } from '../lib/theme';
-import Widgets from './widgets';
-import widgetShape from '../lib/widget-shape';
+import Logo from '@components/logo';
+import { SpacedRow, Row } from '@components/row';
+import Date from '@components/date';
+import TimeHero from '@components/time-hero';
+import Wifi from '@components/wifi';
+import Bathroom from '@components/bathroom';
+import { spacing, colors } from '@lib/theme';
+import Widgets from '@components/widgets';
+import widgetShape from '@lib/widget-shape';
 
 const DateLogoRow = styled(SpacedRow)`
   align-items: center;

--- a/app/javascript/components/full-panel.jsx
+++ b/app/javascript/components/full-panel.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Wrapper from './panel-wrapper';
+import Wrapper from '@components/panel-wrapper';
 
 export const FullPanel = ({ currentWidget }) => (
   <Wrapper>{currentWidget}</Wrapper>

--- a/app/javascript/components/live-stream.jsx
+++ b/app/javascript/components/live-stream.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Wrapper from './panel-wrapper';
+import Wrapper from '@components/panel-wrapper';
 
 export const Live = () => <Wrapper />;
 

--- a/app/javascript/components/logo.jsx
+++ b/app/javascript/components/logo.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import logoImage from '../../assets/images/logo.png';
+import logoImage from '@images/logo.png';
 
 export const Logo = () => (
   <img src={logoImage} alt="helios" width={62} height={54} />

--- a/app/javascript/components/panel-wrapper.jsx
+++ b/app/javascript/components/panel-wrapper.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { colors } from '../lib/theme';
+import { colors } from '@lib/theme';
 
 export const Wrapper = styled.div`
   background: ${colors.black};

--- a/app/javascript/components/side-panel.jsx
+++ b/app/javascript/components/side-panel.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
-import { spacing } from '../lib/theme';
-import FixedContent from './fixed-content';
-import widgetShape from '../lib/widget-shape';
+import { spacing } from '@lib/theme';
+import FixedContent from '@components/fixed-content';
+import widgetShape from '@lib/widget-shape';
 
 const Wrapper = styled.div`
   bottom: 0;

--- a/app/javascript/components/tabs.jsx
+++ b/app/javascript/components/tabs.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { colors, fontSizes } from '../lib/theme';
+import { colors, fontSizes } from '@lib/theme';
 
 const CurrentWidgetText = styled.div`
   margin-top: 19px;

--- a/app/javascript/components/time-hero.jsx
+++ b/app/javascript/components/time-hero.jsx
@@ -2,13 +2,10 @@ import React from 'react';
 import styled from 'styled-components';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
-import { SpacedRow } from './row';
-import Time from './time';
-import { spacing } from '../lib/theme';
-import {
-  LoadingMessage,
-  ErrorMessage,
-} from './widgets/messages/default-messages';
+import { SpacedRow } from '@components/row';
+import Time from '@components/time';
+import { spacing } from '@lib/theme';
+import { LoadingMessage, ErrorMessage } from '@messages/default-messages';
 
 const Wrapper = styled(SpacedRow)`
   align-items: flex-end;

--- a/app/javascript/components/time.jsx
+++ b/app/javascript/components/time.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { colors, fontSizes, weights, fonts } from '../lib/theme';
-import { Row } from './row';
-import { timeForTimezone } from '../lib/datetime';
+import { colors, fontSizes, weights, fonts } from '@lib/theme';
+import { Row } from '@components/row';
+import { timeForTimezone } from '@lib/datetime';
 
 const Wrapper = styled.div`
   font-size: ${fontSizes.medium};

--- a/app/javascript/components/twitter.jsx
+++ b/app/javascript/components/twitter.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Wrapper from './panel-wrapper';
+import Wrapper from '@components/panel-wrapper';
 
 export const Twitter = () => <Wrapper />;
 

--- a/app/javascript/components/typography.jsx
+++ b/app/javascript/components/typography.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { colors, fontSizes, spacing } from '../lib/theme';
+import { colors, fontSizes, spacing } from '@lib/theme';
 
 export const GreyText = styled.div`
   color: ${colors.grey};

--- a/app/javascript/components/widget-controller.jsx
+++ b/app/javascript/components/widget-controller.jsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import styled from 'styled-components';
 import { mathMod } from 'ramda';
-import FullPanel from './full-panel';
-import SidePanel from './side-panel';
-import Twitter from './twitter';
-import Numbers from './widgets/numbers';
-import Weather from './widgets/weather';
-import Guests from './widgets/guests';
-import Live from './live-stream';
-import lockedIcon from '../../assets/images/locked.svg';
-import unlockedIcon from '../../assets/images/unlocked.svg';
-import { colors } from '../lib/theme';
+import FullPanel from '@components/full-panel';
+import SidePanel from '@components/side-panel';
+import Twitter from '@components/twitter';
+import Numbers from '@widgets/numbers';
+import Weather from '@widgets/weather';
+import Guests from '@widgets/guests';
+import Live from '@components/live-stream';
+import lockedIcon from '@images/locked.svg';
+import unlockedIcon from '@images/unlocked.svg';
+import { colors } from '@lib/theme';
 
 const IconWrapper = styled.div`
   position: absolute;

--- a/app/javascript/components/widgets.jsx
+++ b/app/javascript/components/widgets.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
-import { spacing } from '../lib/theme';
-import { Tab } from './tabs';
-import widgetShape from '../lib/widget-shape';
+import { spacing } from '@lib/theme';
+import { Tab } from '@components/tabs';
+import widgetShape from '@lib/widget-shape';
 
 const WidgetContainer = styled.div`
   margin-bottom: ${spacing.l};

--- a/app/javascript/components/widgets/guests/panel.jsx
+++ b/app/javascript/components/widgets/guests/panel.jsx
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 import styled from 'styled-components';
-import { parseDate } from '../../../lib/datetime';
-import { colors, weights, fontSizes, spacing } from '../../../lib/theme';
-import { LoadingMessage, DisconnectedMessage } from '../messages/message';
+import { parseDate } from '@lib/datetime';
+import { colors, weights, fontSizes, spacing } from '@lib/theme';
+import { LoadingMessage, DisconnectedMessage } from '@messages/message';
 
 const getPrimaryLocationAnnouncements = gql`
   {

--- a/app/javascript/components/widgets/guests/tab.jsx
+++ b/app/javascript/components/widgets/guests/tab.jsx
@@ -4,9 +4,9 @@ import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 import { sortBy, prop, append, lensPath, set, filter } from 'ramda';
 import styled from 'styled-components';
-import icon from '../../../../assets/images/icons/icon-calendar.svg';
-import { parseTime, isInFutureToday } from '../../../lib/datetime';
-import { LoadingMessage, DisconnectedMessage } from '../messages/message';
+import icon from '@icons/icon-calendar.svg';
+import { parseTime, isInFutureToday } from '@lib/datetime';
+import { LoadingMessage, DisconnectedMessage } from '@messages/message';
 
 const subscribeAnnouncementPublished = gql`
   subscription onAnnouncementPublished {

--- a/app/javascript/components/widgets/messages/message.jsx
+++ b/app/javascript/components/widgets/messages/message.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { GreySubText } from '../../typography';
-import { fontSizes, leftPanelWidth } from '../../../lib/theme';
-import sunMoon from '../../../../assets/images/sunmoon.png';
+import { GreySubText } from '@components/typography';
+import { fontSizes, leftPanelWidth } from '@lib/theme';
+import sunMoon from '@images/sunmoon.png';
 
 export const LoadingMessage = () => <Message message="Loading..." />;
 export const DisconnectedMessage = () => (

--- a/app/javascript/components/widgets/numbers/falling-blocks.jsx
+++ b/app/javascript/components/widgets/numbers/falling-blocks.jsx
@@ -4,12 +4,12 @@ import { graphql, withApollo } from 'react-apollo';
 import { pathOr, keys, compose } from 'ramda';
 import Resurrect from 'resurrect-js';
 import PropTypes from 'prop-types';
-import { getEventCounts } from './queries';
-import githubPull from '../../../../assets/images/pr.png';
-import githubCommit from '../../../../assets/images/commit.png';
-import slackMessage from '../../../../assets/images/slack.png';
-import { getStartOfWeek } from '../../../lib/datetime';
-import { withLocalMutation, withLocalState } from './ducks';
+import { getEventCounts } from '@numbers/queries';
+import githubPull from '@images/pr.png';
+import githubCommit from '@images/commit.png';
+import slackMessage from '@images/slack.png';
+import { getStartOfWeek } from '@lib/datetime';
+import { withLocalMutation, withLocalState } from '@numbers/ducks';
 
 const blockTypes = { githubPull, githubCommit, slackMessage };
 

--- a/app/javascript/components/widgets/numbers/index.jsx
+++ b/app/javascript/components/widgets/numbers/index.jsx
@@ -1,5 +1,5 @@
-import Tab from './tab';
-import Panel from './panel';
+import Tab from '@numbers/tab';
+import Panel from '@numbers/panel';
 
 export default {
   Tab,

--- a/app/javascript/components/widgets/numbers/panel.jsx
+++ b/app/javascript/components/widgets/numbers/panel.jsx
@@ -4,11 +4,11 @@ import { Query } from 'react-apollo';
 import numeral from 'numeral';
 import styled from 'styled-components';
 import pluralize from 'pluralize';
-import { getStartOfWeek } from '../../../lib/datetime';
-import { LoadingMessage, DisconnectedMessage } from '../messages/message';
-import { colors, weights, fontSizes } from '../../../lib/theme';
-import FallingBlocks from './falling-blocks';
-import { getEventCounts } from './queries';
+import { getStartOfWeek } from '@lib/datetime';
+import { LoadingMessage, DisconnectedMessage } from '@messages/message';
+import { colors, weights, fontSizes } from '@lib/theme';
+import FallingBlocks from '@numbers/falling-blocks';
+import { getEventCounts } from '@numbers/queries';
 
 const NumbersTitle = styled.div`
   color: ${colors.white};

--- a/app/javascript/components/widgets/numbers/tab.jsx
+++ b/app/javascript/components/widgets/numbers/tab.jsx
@@ -4,9 +4,9 @@ import { Query } from 'react-apollo';
 import numeral from 'numeral';
 import { over, lensPath, inc } from 'ramda';
 import pluralize from 'pluralize';
-import { getStartOfWeek } from '../../../lib/datetime';
-import { getEventCounts, subscribeEventPublished } from './queries';
-import { LoadingMessage, ErrorMessage } from '../messages/default-messages';
+import { getStartOfWeek } from '@lib/datetime';
+import { getEventCounts, subscribeEventPublished } from '@numbers/queries';
+import { LoadingMessage, ErrorMessage } from '@messages/default-messages';
 
 const STAT_FORMAT = '0,0';
 

--- a/app/javascript/components/widgets/weather/current-temp.jsx
+++ b/app/javascript/components/widgets/weather/current-temp.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
-import withFragment from '../../hocs/with-fragment';
+import withFragment from '@hocs/with-fragment';
 
 const getCurrentTemp = gql`
   fragment CurrentTemp on Weather {

--- a/app/javascript/components/widgets/weather/daily-weather.jsx
+++ b/app/javascript/components/widgets/weather/daily-weather.jsx
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { take } from 'ramda';
 import styled from 'styled-components';
-import { colors, fontSizes, weights, spacing } from '../../../lib/theme';
-import { parseDay } from '../../../lib/datetime';
-import { WhiteText } from '../../typography';
-import { Row } from '../../row';
-import { SmallSkyIcon } from './sky-icons';
-import withFragment from '../../hocs/with-fragment';
+import { colors, fontSizes, weights, spacing } from '@lib/theme';
+import { parseDay } from '@lib/datetime';
+import { WhiteText } from '@components/typography';
+import { Row } from '@components/row';
+import { SmallSkyIcon } from '@weather/sky-icons';
+import withFragment from '@hocs/with-fragment';
 
 const Wrapper = styled(Row)`
   color: ${colors.grey};

--- a/app/javascript/components/widgets/weather/hourly-temps.jsx
+++ b/app/javascript/components/widgets/weather/hourly-temps.jsx
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { take } from 'ramda';
 import styled from 'styled-components';
-import { colors, fontSizes, spacing, fonts, weights } from '../../../lib/theme';
-import { Row } from '../../row';
-import { parseHour } from '../../../lib/datetime';
-import rainIcon from '../../../../assets/images/raincloud.png';
-import withFragment from '../../hocs/with-fragment';
+import { colors, fontSizes, spacing, fonts, weights } from '@lib/theme';
+import { Row } from '@components/row';
+import { parseHour } from '@lib/datetime';
+import rainIcon from '@images/raincloud.png';
+import withFragment from '@hocs/with-fragment';
 
 const opacities = {
   0: '1',

--- a/app/javascript/components/widgets/weather/index.jsx
+++ b/app/javascript/components/widgets/weather/index.jsx
@@ -1,5 +1,5 @@
-import Tab from './tab';
-import Panel from './panel';
+import Tab from '@weather/tab';
+import Panel from '@weather/panel';
 
 export default {
   Tab,

--- a/app/javascript/components/widgets/weather/minutely-weather.jsx
+++ b/app/javascript/components/widgets/weather/minutely-weather.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import styled from 'styled-components';
-import withFragment from '../../hocs/with-fragment';
-import { SmallSkyIcon, LargeSkyIcon } from './sky-icons';
+import withFragment from '@hocs/with-fragment';
+import { SmallSkyIcon, LargeSkyIcon } from '@weather/sky-icons';
 
 const getMinutelyWeather = gql`
   fragment MinutelyWeather on Weather {

--- a/app/javascript/components/widgets/weather/moon-phase.jsx
+++ b/app/javascript/components/widgets/weather/moon-phase.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { colors } from '../../../lib/theme';
+import { colors } from '@lib/theme';
 
 const iconRender = (posX, posY, radius, phase) => {
   const shouldHideFront =

--- a/app/javascript/components/widgets/weather/panel.jsx
+++ b/app/javascript/components/widgets/weather/panel.jsx
@@ -4,13 +4,13 @@ import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
 import { assocPath } from 'ramda';
 import styled from 'styled-components';
-import CurrentTemp from './current-temp';
-import HourlyTemps from './hourly-temps';
-import MinutelyWeather from './minutely-weather';
-import DailyWeather from './daily-weather';
-import SunriseSunset from './sunrise-sunset';
-import { LoadingMessage, DisconnectedMessage } from '../messages/message';
-import { Row } from '../../row';
+import CurrentTemp from '@weather/current-temp';
+import HourlyTemps from '@weather/hourly-temps';
+import MinutelyWeather from '@weather/minutely-weather';
+import DailyWeather from '@weather/daily-weather';
+import SunriseSunset from '@weather/sunrise-sunset';
+import { LoadingMessage, DisconnectedMessage } from '@messages/message';
+import { Row } from '@components/row';
 import {
   colors,
   weights,
@@ -18,8 +18,8 @@ import {
   spacing,
   fonts,
   leftPanelWidth,
-} from '../../../lib/theme';
-import { GreySubText, WhiteText } from '../../typography';
+} from '@lib/theme';
+import { GreySubText, WhiteText } from '@components/typography';
 
 const Column = styled.div`
   display: flex;

--- a/app/javascript/components/widgets/weather/semi-circle.jsx
+++ b/app/javascript/components/widgets/weather/semi-circle.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import cityImage from '../../../../assets/images/buildings.png';
-import { yValue, xValue } from '../../../lib/circle-math';
-import {
-  timeDiffInMinutes,
-  timeAndDateForTimezone,
-} from '../../../lib/datetime';
-import { colors } from '../../../lib/theme';
-import MoonPhase from './moon-phase';
+import cityImage from '@images/buildings.png';
+import { yValue, xValue } from '@lib/circle-math';
+import { timeDiffInMinutes, timeAndDateForTimezone } from '@lib/datetime';
+import { colors } from '@lib/theme';
+import MoonPhase from '@weather/moon-phase';
 
 const getPhaseType = phase => {
   if (phase === 0) return 'newMoon';

--- a/app/javascript/components/widgets/weather/sky-icons.jsx
+++ b/app/javascript/components/widgets/weather/sky-icons.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ClearDayIcon from '../../../../assets/images/icons/icon-29-sun.svg';
-import ClearNightIcon from '../../../../assets/images/icons/icon-28-moon.svg';
-import RainIcon from '../../../../assets/images/icons/icon-4-cloud-rain.svg';
-import SnowIcon from '../../../../assets/images/icons/icon-17-cloud-snowflakes.svg';
-import SleetIcon from '../../../../assets/images/icons/icon-7-cloud-snow.svg';
-import WindIcon from '../../../../assets/images/icons/icon-43-wind.svg';
-import FogIcon from '../../../../assets/images/icons/icon-24-cloud-fog.svg';
-import CloudyIcon from '../../../../assets/images/icons/icon-1-cloud.svg';
-import PartlyCloudyDayIcon from '../../../../assets/images/icons/icon-2-cloud-sun.svg';
-import PartlyCloudyNightIcon from '../../../../assets/images/icons/icon-3-cloud-moon.svg';
+import ClearDayIcon from '@icons/icon-29-sun.svg';
+import ClearNightIcon from '@icons/icon-28-moon.svg';
+import RainIcon from '@icons/icon-4-cloud-rain.svg';
+import SnowIcon from '@icons/icon-17-cloud-snowflakes.svg';
+import SleetIcon from '@icons/icon-7-cloud-snow.svg';
+import WindIcon from '@icons/icon-43-wind.svg';
+import FogIcon from '@icons/icon-24-cloud-fog.svg';
+import CloudyIcon from '@icons/icon-1-cloud.svg';
+import PartlyCloudyDayIcon from '@icons/icon-2-cloud-sun.svg';
+import PartlyCloudyNightIcon from '@icons/icon-3-cloud-moon.svg';
 
 const iconMapping = {
   'clear-day': ClearDayIcon,

--- a/app/javascript/components/widgets/weather/sunrise-sunset.jsx
+++ b/app/javascript/components/widgets/weather/sunrise-sunset.jsx
@@ -9,11 +9,11 @@ import {
   weights,
   spacing,
   leftPanelWidth,
-} from '../../../lib/theme';
-import { parseTime, timeDiffInMinutes } from '../../../lib/datetime';
-import { WhiteText } from '../../typography';
-import withFragment from '../../hocs/with-fragment';
-import SemiCircle from './semi-circle';
+} from '@lib/theme';
+import { parseTime, timeDiffInMinutes } from '@lib/datetime';
+import { WhiteText } from '@components/typography';
+import withFragment from '@hocs/with-fragment';
+import SemiCircle from '@weather/semi-circle';
 
 const containerHeight = '344px';
 

--- a/app/javascript/components/widgets/weather/tab.jsx
+++ b/app/javascript/components/widgets/weather/tab.jsx
@@ -4,9 +4,9 @@ import gql from 'graphql-tag';
 import styled from 'styled-components';
 import { Query } from 'react-apollo';
 import { assocPath } from 'ramda';
-import CurrentTemp from './current-temp';
-import MinutelyWeather from './minutely-weather';
-import { LoadingMessage, ErrorMessage } from '../messages/default-messages';
+import CurrentTemp from '@weather/current-temp';
+import MinutelyWeather from '@weather/minutely-weather';
+import { LoadingMessage, ErrorMessage } from '@messages/default-messages';
 
 const SummaryTextWrapper = styled.div`
   display: flex;

--- a/app/javascript/components/wifi.jsx
+++ b/app/javascript/components/wifi.jsx
@@ -2,12 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
-import { WhiteSubTitle, WhiteTitleLarge } from './typography';
-import { Row } from './row';
-import {
-  LoadingMessage,
-  ErrorMessage,
-} from './widgets/messages/default-messages';
+import { WhiteSubTitle, WhiteTitleLarge } from '@components/typography';
+import { Row } from '@components/row';
+import { LoadingMessage, ErrorMessage } from '@messages/default-messages';
 
 const Column = styled.div`
   display: flex;

--- a/app/javascript/styles.js
+++ b/app/javascript/styles.js
@@ -1,6 +1,6 @@
 import styledNormalize from 'styled-normalize';
 import { injectGlobal } from 'styled-components';
-import { fonts } from 'lib/theme';
+import { fonts } from '@lib/theme';
 
 const injectBaseStyles = () => injectGlobal`
   ${styledNormalize}

--- a/config/transforms/relative_to_alias_path.js
+++ b/config/transforms/relative_to_alias_path.js
@@ -1,0 +1,50 @@
+import custom from '../webpack/webpack.config.custom';
+
+const path = require('path');
+
+const { alias } = custom.resolve;
+
+const isRelative = (filePath = '') => filePath[0] === '.';
+const filterNonRelative = p => isRelative(p.value.value);
+
+const getKeyByValue = (object, value) =>
+  Object.keys(object).find(key => object[key] === value);
+
+const renameLiteral = (j, newPath) => p => {
+  j(p).replaceWith(() => j.literal(newPath));
+};
+
+export default (fileInfo, api) => {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+  const fileAbsPath = fileInfo.path;
+
+  const importDeclarations = root
+    .find(j.ImportDeclaration)
+    .find(j.Literal)
+    .filter(filterNonRelative);
+
+  const aliasImports = [];
+  importDeclarations.paths().forEach(importDeclaration => {
+    const relativeImport = importDeclaration.value.value;
+    const correspondingAlias = getKeyByValue(
+      alias,
+      path.dirname(path.resolve(path.dirname(fileAbsPath), relativeImport)),
+    );
+
+    if (correspondingAlias) {
+      aliasImports.push(
+        correspondingAlias.concat('/', path.basename(relativeImport)),
+      );
+    } else {
+      aliasImports.push(relativeImport);
+    }
+  });
+
+  importDeclarations.forEach((importDeclaration, i) => {
+    const rewriter = renameLiteral(j, aliasImports[i]);
+    rewriter(importDeclaration);
+  });
+
+  return root.toSource();
+};

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,3 @@
-const { environment } = require('@rails/webpacker')
+const { environment } = require('@rails/webpacker');
 
-module.exports = environment
+module.exports = environment;

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,5 @@
 const { environment } = require('@rails/webpacker');
+const customConfig = require('./webpack.config.custom');
 
+environment.config.merge(customConfig);
 module.exports = environment;

--- a/config/webpack/webpack.config.custom.js
+++ b/config/webpack/webpack.config.custom.js
@@ -1,0 +1,34 @@
+const path = require('path');
+
+module.exports = {
+  resolve: {
+    alias: {
+      '@root': path.resolve(__dirname, '../..'),
+      '@app': path.resolve(__dirname, '../../app'),
+      '@javascript': path.resolve(__dirname, '../../app/javascript'),
+      '@lib': path.resolve(__dirname, '../../app/javascript/lib'),
+      '@components': path.resolve(__dirname, '../../app/javascript/components'),
+      '@widgets': path.resolve(
+        __dirname,
+        '../../app/javascript/components/widgets',
+      ),
+      '@messages': path.resolve(
+        __dirname,
+        '../../app/javascript/components/widgets/messages',
+      ),
+      '@numbers': path.resolve(
+        __dirname,
+        '../../app/javascript/components/widgets/numbers',
+      ),
+      '@weather': path.resolve(
+        __dirname,
+        '../../app/javascript/components/widgets/weather',
+      ),
+      '@hocs': path.resolve(__dirname, '../../app/javascript/components/hocs'),
+      '@assets': path.resolve(__dirname, '../../app/assets'),
+      '@images': path.resolve(__dirname, '../../app/assets/images'),
+      '@icons': path.resolve(__dirname, '../../app/assets/images/icons'),
+    },
+    extensions: ['.jsx', '.js'],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
   },
   "scripts": {
     "lint": "./node_modules/.bin/eslint --ext js --ext jsx app/javascript/",
-    "test": "jest"
+    "test": "jest",
+    "relative-to-alias": "jscodeshift --extensions jsx -t ./config/transforms/relative_to_alias_path.js ./ "
   },
   "jest": {
     "verbose": true,

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-react": "^7.13.0",
     "eslint-plugin-react-hooks": "^1.6.0",
     "jest": "24.8.0",
+    "jscodeshift": "^0.6.4",
     "prettier": "^1.18.2",
     "react-svg-loader": "^3.0.3",
     "require-yaml": "^0.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,7 +29,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.4.5":
+"@babel/core@^7.1.6", "@babel/core@^7.4.5":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.5.tgz#081f97e8ffca65a9b4b0fdc7e274e703f000c06a"
   integrity sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==
@@ -314,7 +314,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.3.tgz#eb3ac80f64aa101c907d4ce5406360fe75b7895b"
   integrity sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==
 
-"@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
+"@babel/parser@^7.1.6", "@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.5.tgz#04af8d5d5a2b044a2a1bffacc1e5e6673544e872"
   integrity sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==
@@ -328,7 +328,7 @@
     "@babel/helper-remap-async-to-generator" "^7.1.0"
     "@babel/plugin-syntax-async-generators" "^7.2.0"
 
-"@babel/plugin-proposal-class-properties@^7.4.4":
+"@babel/plugin-proposal-class-properties@^7.1.0", "@babel/plugin-proposal-class-properties@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.4.tgz#93a6486eed86d53452ab9bab35e368e9461198ce"
   integrity sha512-WjKTI8g8d5w1Bc9zgwSz2nfrsNQsXcCf9J9cdCvrJV6RF56yztwm4TmJC0MgJ9tvwO9gUA/mcYe89bLdGfiXFg==
@@ -344,7 +344,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-json-strings" "^7.2.0"
 
-"@babel/plugin-proposal-object-rest-spread@^7.4.4":
+"@babel/plugin-proposal-object-rest-spread@^7.0.0", "@babel/plugin-proposal-object-rest-spread@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz#1ef173fcf24b3e2df92a678f027673b55e7e3005"
   integrity sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==
@@ -383,6 +383,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-flow@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.2.0.tgz#a765f061f803bc48f240c26f8747faf97c26bf7c"
+  integrity sha512-r6YMuZDWLtLlu0kqIim5o/3TNRAlWb073HwT3e2nKf9I8IIvOggPrnILYPsrrKilmn/mYEMCf/Z07w3yQJF6dg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-syntax-json-strings@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.2.0.tgz#72bd13f6ffe1d25938129d2a186b11fd62951470"
@@ -408,6 +415,13 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz#a94013d6eda8908dfe6a477e7f9eda85656ecf5c"
   integrity sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-typescript@^7.2.0":
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz#a7cc3f66119a9f7ebe2de5383cce193473d65991"
+  integrity sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -493,6 +507,14 @@
   dependencies:
     "@babel/helper-builder-binary-assignment-operator-visitor" "^7.1.0"
     "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-flow-strip-types@^7.0.0":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.4.tgz#d267a081f49a8705fc9146de0768c6b58dccd8f7"
+  integrity sha512-WyVedfeEIILYEaWGAUWzVNyqG4sfsNooMhXWsu/YzOvVGcsnPb5PguysjJqI3t3qiaYj0BR8T2f5njdjTGe44Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-flow" "^7.2.0"
 
 "@babel/plugin-transform-for-of@^7.4.4":
   version "7.4.4"
@@ -687,6 +709,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-typescript@^7.3.2":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.5.tgz#ab3351ba35307b79981993536c93ff8be050ba28"
+  integrity sha512-RPB/YeGr4ZrFKNwfuQRlMf2lxoCUaU01MTw39/OFE/RiL8HDjtn68BwEPft1P7JN4akyEmjGWAMNldOV7o9V2g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-typescript" "^7.2.0"
+
 "@babel/plugin-transform-unicode-regex@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz#ab4634bb4f14d36728bf5978322b35587787970f"
@@ -696,7 +726,7 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.5.4"
 
-"@babel/preset-env@^7.4.5":
+"@babel/preset-env@^7.1.6", "@babel/preset-env@^7.4.5":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.4.5.tgz#2fad7f62983d5af563b5f3139242755884998a58"
   integrity sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==
@@ -750,6 +780,14 @@
     js-levenshtein "^1.1.3"
     semver "^5.5.0"
 
+"@babel/preset-flow@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.0.0.tgz#afd764835d9535ec63d8c7d4caf1c06457263da2"
+  integrity sha512-bJOHrYOPqJZCkPVbG1Lot2r5OSsB+iUOaxiHdlOeB1yPWS6evswVHwvkDLZ54WTaTRIk89ds0iHmGZSnxlPejQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
+
 "@babel/preset-react@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.0.0.tgz#e86b4b3d99433c7b3e9e91747e2653958bc6b3c0"
@@ -760,6 +798,26 @@
     "@babel/plugin-transform-react-jsx" "^7.0.0"
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
+
+"@babel/preset-typescript@^7.1.0":
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz#88669911053fa16b2b276ea2ede2ca603b3f307a"
+  integrity sha512-mzMVuIP4lqtn4du2ynEfdO0+RYcslwrZiJHXu4MGaC1ctJiW2fyaeDrtjJGs7R/KebZ1sgowcIoWf4uRpEfKEg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-transform-typescript" "^7.3.2"
+
+"@babel/register@^7.0.0":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.4.4.tgz#370a68ba36f08f015a8b35d4864176c6b65d7a23"
+  integrity sha512-sn51H88GRa00+ZoMqCVgOphmswG4b7mhf9VOB0LUBAieykq2GnRFerlN+JQkO/ntT7wz4jaHNSRPg9IdMPEUkA==
+  dependencies:
+    core-js "^3.0.0"
+    find-cache-dir "^2.0.0"
+    lodash "^4.17.11"
+    mkdirp "^0.5.1"
+    pirates "^4.0.0"
+    source-map-support "^0.5.9"
 
 "@babel/runtime@^7.4.2":
   version "7.4.3"
@@ -1673,6 +1731,11 @@ ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
+ast-types@0.11.7:
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.7.tgz#f318bf44e339db6a320be0009ded64ec1471f46c"
+  integrity sha512-2mP3TwtkY/aTv5X3ZsMpNAbOnyoC/aMJwJSoaELPkHId0nSQgFcnU4dRW3isxiz7+zBexk0ym3WNVjMiQBnJSw==
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -1736,6 +1799,11 @@ axobject-query@^2.0.2:
   integrity sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==
   dependencies:
     ast-types-flow "0.0.7"
+
+babel-core@^7.0.0-bridge.0:
+  version "7.0.0-bridge.0"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
+  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
 
 babel-eslint@^10.0.1:
   version "10.0.1"
@@ -2406,6 +2474,11 @@ color@^3.0.0:
     color-convert "^1.9.1"
     color-string "^1.5.2"
 
+colors@^1.1.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
+  integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
+
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
@@ -2562,7 +2635,7 @@ core-js-pure@3.1.3:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.3.tgz#4c90752d5b9471f641514f3728f51c1e0783d0b5"
   integrity sha512-k3JWTrcQBKqjkjI0bkfXS0lbpWPxYuHWfMMjC1VDmzU4Q58IwSbuXSo99YO/hUHlw/EB4AlfA2PVxOGkrIq6dA==
 
-core-js@3.1.3, core-js@^3.1.3:
+core-js@3.1.3, core-js@^3.0.0, core-js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.1.3.tgz#95700bca5f248f5f78c0ec63e784eca663ec4138"
   integrity sha512-PWZ+ZfuaKf178BIAg+CRsljwjIMRV8MY00CbZczkR6Zk5LfkSkjGoaab3+bqRQWVITNZxQB7TFYz+CFcyuamvA==
@@ -3537,7 +3610,7 @@ esprima@^3.1.3:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
   integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
 
-esprima@^4.0.0:
+esprima@^4.0.0, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -3908,6 +3981,11 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
+
+flow-parser@0.*:
+  version "0.101.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.101.0.tgz#9d355cd749ef526e99aecb3b195980e2567ab07c"
+  integrity sha512-Goi71MNzZkL530ZEEpedxLlFFiCA/M4J+nJA8zHSTSpHnDCL3WYpr2NYFHmUczpG80Hq9xTYdQYfGQEk7Dl5Ww==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -5409,6 +5487,30 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
+jscodeshift@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-0.6.4.tgz#e19ab86214edac86a75c4557fc88b3937d558a8e"
+  integrity sha512-+NF/tlNbc2WEhXUuc4WEJLsJumF84tnaMUZW2hyJw3jThKKRvsPX4sPJVgO1lPE28z0gNL+gwniLG9d8mYvQCQ==
+  dependencies:
+    "@babel/core" "^7.1.6"
+    "@babel/parser" "^7.1.6"
+    "@babel/plugin-proposal-class-properties" "^7.1.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
+    "@babel/preset-env" "^7.1.6"
+    "@babel/preset-flow" "^7.0.0"
+    "@babel/preset-typescript" "^7.1.0"
+    "@babel/register" "^7.0.0"
+    babel-core "^7.0.0-bridge.0"
+    colors "^1.1.2"
+    flow-parser "0.*"
+    graceful-fs "^4.1.11"
+    micromatch "^3.1.10"
+    neo-async "^2.5.0"
+    node-dir "^0.1.17"
+    recast "^0.16.1"
+    temp "^0.8.1"
+    write-file-atomic "^2.3.0"
+
 jsdom@^11.5.1:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
@@ -5966,7 +6068,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.4, minimatch@~3.0.2:
+minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -6142,6 +6244,13 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-dir@^0.1.17:
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
+  integrity sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=
+  dependencies:
+    minimatch "^3.0.2"
 
 node-fetch@2.1.2:
   version "2.1.2"
@@ -6864,7 +6973,7 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
-pirates@^4.0.1:
+pirates@^4.0.0, pirates@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.1.tgz#643a92caf894566f91b2b986d2c66950a8e2fb87"
   integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
@@ -7587,7 +7696,7 @@ pretty-format@^24.8.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-private@^0.1.6:
+private@^0.1.6, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
   integrity sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==
@@ -7948,6 +8057,16 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
+recast@^0.16.1:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.16.2.tgz#3796ebad5fe49ed85473b479cd6df554ad725dc2"
+  integrity sha512-O/7qXi51DPjRVdbrpNzoBQH5dnAPQNbfoOFyRiUwreTMJfIHYOEBzwuH+c0+/BTSJ3CQyKs6ILSWXhESH6Op3A==
+  dependencies:
+    ast-types "0.11.7"
+    esprima "~4.0.0"
+    private "~0.1.5"
+    source-map "~0.6.1"
+
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -8206,6 +8325,11 @@ rimraf@2, rimraf@2.6.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
+
+rimraf@~2.2.6:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
+  integrity sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
@@ -8582,7 +8706,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.6, source-map-support@~0.5.10:
+source-map-support@^0.5.6, source-map-support@^0.5.9, source-map-support@~0.5.10:
   version "0.5.12"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
   integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
@@ -9009,6 +9133,14 @@ tar@^4:
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
+
+temp@^0.8.1:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
+  integrity sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=
+  dependencies:
+    os-tmpdir "^1.0.0"
+    rimraf "~2.2.6"
 
 terser-webpack-plugin@^1.1.0:
   version "1.2.3"
@@ -9747,6 +9879,15 @@ write-file-atomic@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.1.tgz#d0b05463c188ae804396fd5ab2a370062af87529"
   integrity sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
+write-file-atomic@^2.3.0:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
+  integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"


### PR DESCRIPTION
- Defined aliases for React directories in the `webpack.config.custom.js` file.
- Created a transform file using `jscodeshift` to transform relative imports to alias imports when an alias is found.
- Automated changing relative to absolute imports in .jsx files with the `npm run relative-to-alias` script. After running this, `prettier` needs to be run in all files because all imports are done with double quotes instead of single quotes.
- The `styles.js` and `date.jsx` files both imported functions from `lib/datetime`, which is not a relative import and so was not changed when the script was run, but then was not recognized by eslint, so I manually added a `@` at the beginning of the import.