### PR TITLE
fix: remove trailing 0 from time

### DIFF
--- a/app/javascript/lib/datetime.js
+++ b/app/javascript/lib/datetime.js
@@ -2,7 +2,7 @@ import { format, isSameDay, differenceInMinutes, startOfWeek } from 'date-fns';
 import { utcToZonedTime } from 'date-fns-tz';
 
 export const timeForTimezone = (timezone, date = new Date()) =>
-  format(utcToZonedTime(new Date(date), timezone), 'hh:mm aa');
+  format(utcToZonedTime(new Date(date), timezone), 'h:mm aa');
 
 export const dateForTimezone = (timezone, date = new Date()) =>
   format(utcToZonedTime(new Date(date), timezone), 'EEEE, MMM dd, yyyy');

--- a/app/javascript/lib/datetime.test.js
+++ b/app/javascript/lib/datetime.test.js
@@ -12,9 +12,9 @@ import {
 
 describe('#timeForTimezone', () => {
   const timeZone = 'America/New_York';
-  const datetime = '2020-05-13T04:00:00.000Z';
+  const datetime = '2020-05-13T05:00:00.000Z';
   it('returns the hour, minute and period for a timestamp in a specific timezone', () => {
-    expect(timeForTimezone(timeZone, datetime)).toEqual('12:00 AM');
+    expect(timeForTimezone(timeZone, datetime)).toEqual('1:00 AM');
   });
 });
 


### PR DESCRIPTION
Change `hh` to `h` for time, which was accidentally switched when implementing everything with `date-fns`