### PR TITLE
Add widgets table and model

### DIFF
--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -1,0 +1,4 @@
+class Widget < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+  validates :position, presence: true, uniqueness: true
+end

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -1,4 +1,7 @@
 class Widget < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   validates :position, presence: true, uniqueness: true
+
+  default_scope { order(position: :asc) }
+  scope :enabled, -> { where(enabled: true) }
 end

--- a/db/migrate/20190604172236_create_widgets.rb
+++ b/db/migrate/20190604172236_create_widgets.rb
@@ -1,0 +1,12 @@
+class CreateWidgets < ActiveRecord::Migration[5.2]
+  def change
+    create_table :widgets do |t|
+      t.string :name, null: false
+      t.boolean :enabled, null: false
+      t.integer :duration_seconds, null: false
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_061410) do
-
-  create_table "daily_event_summaries", force: :cascade do |t|
-    t.string "source", null: false
-    t.date "day", null: false
-    t.integer "count", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
+ActiveRecord::Schema.define(version: 2019_06_04_172236) do
 
   create_table "announcements", force: :cascade do |t|
     t.datetime "publish_on", null: false
@@ -30,6 +22,14 @@ ActiveRecord::Schema.define(version: 2019_05_31_061410) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["location_id"], name: "index_announcements_on_location_id"
+  end
+
+  create_table "daily_event_summaries", force: :cascade do |t|
+    t.string "source", null: false
+    t.date "day", null: false
+    t.integer "count", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "events", force: :cascade do |t|
@@ -45,6 +45,15 @@ ActiveRecord::Schema.define(version: 2019_05_31_061410) do
     t.float "longitude", null: false
     t.string "city_name", null: false
     t.string "time_zone", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "widgets", force: :cascade do |t|
+    t.string "name", null: false
+    t.boolean "enabled", null: false
+    t.integer "duration_seconds", null: false
+    t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,3 +25,31 @@ Location.create(
   city_name: 'NYC',
   time_zone: 'America/New_York'
 )
+
+Widget.create(
+  name: "Guests",
+  enabled: false,
+  duration_seconds: 20,
+  position: 0
+)
+
+Widget.create(
+  name: "Weather",
+  enabled: true,
+  duration_seconds: 20,
+  position: 1
+)
+
+Widget.create(
+  name: "Twitter",
+  enabled: true,
+  duration_seconds: 20,
+  position: 2
+)
+
+Widget.create(
+  name: "Numbers",
+  enabled: true,
+  duration_seconds: 20,
+  position: 3
+)


### PR DESCRIPTION
- Backend to store Widgets that will be rendered in the frontend
- Stores: `name` which matches frontend naming, `enabled` flag, `duration_seconds` of the display, `order` of appearance on the side bar
- Scope: `all_in_order` sorted by `order`, and `enabled` which is also sorted by `order`
- Seeds: `Guests`, `Weather`, `Twitter`, `Numbers` in that order
