### PR TITLE
Fix Slack announcement bugs

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -7,3 +7,4 @@ SLACK_CLIENT_ID=
 SLACK_API_SECRET=
 SLACK_REDIRECT_URI=https://mojotech-helios2.herokuapp.com/web_hooks/create_slack_auth
 SLACK_VERIFICATION_TOKEN=
+SLACK_WEBHOOK_URL=

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -35,3 +35,4 @@ The Slack Helios App should be subscribed to all `message` Workspace Events in t
 ### Announcements
 
 The Slack Helios Bot should be subscribed to the `app_mention` Bot Event.
+For the bot to send messages back, the _Incoming Webhooks_ App should be installed from the [Slack App Directory](https://mojotech.slack.com/apps). The `Webhook URL` provided by this app should be supplied to the `SLACK_WEBHOOK_URL` environment variable.

--- a/app/javascript/components/widgets/guests/tab.jsx
+++ b/app/javascript/components/widgets/guests/tab.jsx
@@ -5,7 +5,7 @@ import gql from 'graphql-tag';
 import { sortBy, prop, append, lensPath, set } from 'ramda';
 import styled from 'styled-components';
 import icon from '../../../../assets/images/icons/icon-calendar.svg';
-import { parseTime, isDateToday } from '../../../lib/datetime';
+import { parseTime, isInFutureToday } from '../../../lib/datetime';
 import { LoadingMessage, DisconnectedMessage } from '../messages/message';
 
 const subscribeAnnouncementPublished = gql`
@@ -109,7 +109,7 @@ const Guests = () => (
                 }
                 const { announcementPublished } = subscriptionData.data;
 
-                if (isDateToday(announcementPublished.publishOn)) {
+                if (isInFutureToday(announcementPublished.publishOn)) {
                   return set(
                     lensPath(['primaryLocation', 'dayAnnouncements']),
 
@@ -121,7 +121,6 @@ const Guests = () => (
                     prev,
                   );
                 }
-
                 return prev;
               },
             })

--- a/app/javascript/components/widgets/guests/tab.jsx
+++ b/app/javascript/components/widgets/guests/tab.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
-import { sortBy, prop, append, lensPath, set } from 'ramda';
+import { sortBy, prop, append, lensPath, set, filter } from 'ramda';
 import styled from 'styled-components';
 import icon from '../../../../assets/images/icons/icon-calendar.svg';
 import { parseTime, isInFutureToday } from '../../../lib/datetime';
@@ -121,7 +121,13 @@ const Guests = () => (
                     prev,
                   );
                 }
-                return prev;
+
+                const isFutureToday = item => isInFutureToday(item.publishOn);
+                return set(
+                  lensPath(['primaryLocation', 'dayAnnouncements']),
+                  filter(isFutureToday, prev.primaryLocation.dayAnnouncements),
+                  prev,
+                );
               },
             })
           }

--- a/app/javascript/lib/datetime.js
+++ b/app/javascript/lib/datetime.js
@@ -1,4 +1,10 @@
-import { format, isSameDay, differenceInMinutes, startOfWeek } from 'date-fns';
+import {
+  format,
+  isSameDay,
+  isAfter,
+  differenceInMinutes,
+  startOfWeek,
+} from 'date-fns';
 import { utcToZonedTime } from 'date-fns-tz';
 
 export const timeForTimezone = (timezone, date = new Date()) =>
@@ -24,11 +30,17 @@ export const parseDate = datetime =>
 export const timeDiffInMinutes = (date, other) =>
   differenceInMinutes(date, other);
 
-export const isDateToday = datetime =>
-  isSameDay(new Date(datetime), new Date());
+export const isDateToday = (datetime, today = new Date()) =>
+  isSameDay(new Date(datetime), new Date(today));
 
 export const isDateTomorrow = datetime =>
   isSameDay(new Date(datetime), new Date().setDate(new Date().getDate() + 1));
+
+export const isDateInFuture = (datetime, datetimeToCompare = new Date()) =>
+  isAfter(new Date(datetime), new Date(datetimeToCompare));
+
+export const isInFutureToday = (datetime, today = new Date()) =>
+  isDateToday(datetime, today) && isDateInFuture(datetime, today);
 
 export const parseDay = datetime => {
   if (isDateToday(datetime)) return 'Today';

--- a/app/javascript/lib/datetime.test.js
+++ b/app/javascript/lib/datetime.test.js
@@ -8,6 +8,8 @@ import {
   timeDiffInMinutes,
   isDateToday,
   isDateTomorrow,
+  isDateInFuture,
+  isInFutureToday,
   parseDay,
 } from './datetime';
 
@@ -83,6 +85,28 @@ describe('#isDateTomorrow', () => {
   it('returns true if the given date is tomorrow', () => {
     expect(isDateTomorrow(today)).toEqual(false);
     expect(isDateTomorrow(tomorrow)).toEqual(true);
+  });
+});
+
+describe('#isDateInFuture', () => {
+  const before = new Date(2014, 6, 2, 12, 20, 0);
+  const after = new Date(2016, 6, 2, 12, 20, 0);
+  it('returns true if the first date is after the second', () => {
+    expect(isDateInFuture(after, before)).toEqual(true);
+  });
+});
+
+describe('#isDateInFuture', () => {
+  const now = new Date(2016, 6, 2, 12, 20, 0);
+  const todayFuture = new Date(2016, 6, 2, 14, 20, 0);
+  const todayPast = new Date(2016, 6, 2, 9, 20, 0);
+  const tomorrow = new Date(2016, 6, 3, 12, 20, 0);
+  const yesterday = new Date(2016, 6, 1, 12, 20, 0);
+  it('returns true if date is in future and is today', () => {
+    expect(isInFutureToday(todayFuture, now)).toEqual(true);
+    expect(isInFutureToday(todayPast, now)).toEqual(false);
+    expect(isInFutureToday(tomorrow, now)).toEqual(false);
+    expect(isInFutureToday(yesterday, now)).toEqual(false);
   });
 });
 

--- a/app/lib/simulate/slack-announcement.json.erb
+++ b/app/lib/simulate/slack-announcement.json.erb
@@ -1,19 +1,36 @@
 {
+  "token": "Sim-123456",
+  "team_id": "TXXXXXXXX",
+  "api_app_id": "AXXXXXXXX",
+  "event": {
+    "client_msg_id": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+    "type": "app_mention",
+    "text": "<@UXXXXXXXX> guests: Welcome to Roy and Amanda from Amica on June 6 2019 at 2:30 pm in Providence",
+    "user": "UXXXXXXX",
+    "ts": "1559841520.000700",
+    "channel": "CXXXXXXXX",
+    "event_ts": "1559841520.000700"
+  },
+  "type": "event_callback",
+  "event_id": "<%= @event_id %>",
+  "event_time": 1559841520,
+  "authed_users": ["UXXXXXXXX"],
+  "slack": {
     "token": "Sim-123456",
-    "team_id": "T061EG9R6",
-    "api_app_id": "A0MDYCDME",
+    "team_id": "TXXXXXXX",
+    "api_app_id": "AXXXXXXX",
     "event": {
-        "type": "app_mention",
-        "user": "U061F7AUR",
-        "text": "guests: Welcome to Roy and Amanda from Amica on May 23 2019 at 9:30 pm in Providence",
-        "ts": "1515449438.000011",
-        "channel": "C0LAN2Q65",
-        "event_ts": "1515449438000011"
+      "client_msg_id": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+      "type": "app_mention",
+      "text": "<@UXXXXXXXX> guests: Welcome to Roy and Amanda from Amica on June 6 2019 at 2:30 pm in Providence",
+      "user": "UXXXXXXXX",
+      "ts": "1559841520.000700",
+      "channel": "CXXXXXXXX",
+      "event_ts": "1559841520.000700"
     },
     "type": "event_callback",
-    "event_id": "<%= @event_id %>",
-    "event_time": 1515449438000011,
-    "authed_users": [
-        "U0LAN0Z89"
-    ]
+    "event_id": "EvXXXXXX",
+    "event_time": 1559841520,
+    "authed_users": ["UXXXXXXXX"]
+  }
 }

--- a/app/lib/simulate/slack-message.json.erb
+++ b/app/lib/simulate/slack-message.json.erb
@@ -1,20 +1,38 @@
 {
   "token": "Sim-123456",
   "team_id": "TXXXXXXXX",
-  "api_app_id": "AXXXXXXXXX",
+  "api_app_id": "AXXXXXXXX",
   "event": {
+    "client_msg_id": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
     "type": "message",
-    "user": "U061F7AUR",
-    "text": "Let me recite what history teaches. History teaches.",
-    "thread_ts": "1482960137.003543",
-    "parent_user_id": "U061F7AUR",
-    "ts": "1483051909.018632"
+    "text": "hi",
+    "user": "UXXXXXXXX",
+    "ts": "1559841923.001600",
+    "channel": "CXXXXXXXX",
+    "event_ts": "1559841923.001600",
+    "channel_type": "channel"
   },
   "type": "event_callback",
-  "authed_users": [
-          "UXXXXXXX1",
-          "UXXXXXXX2"
-  ],
   "event_id": "<%= @event_id %>",
-  "event_time": 1234567890
+  "event_time": 1559841923,
+  "authed_users": ["UXXXXXXXX", "UXXXXXXXX"],
+  "slack": {
+    "token": "Sim-123456",
+    "team_id": "TXXXXXXXX",
+    "api_app_id": "AXXXXXX",
+    "event": {
+      "client_msg_id": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+      "type": "message",
+      "text": "hi",
+      "user": "UXXXXXXXX",
+      "ts": "1559841923.001600",
+      "channel": "CXXXXXXXX",
+      "event_ts": "1559841923.001600",
+      "channel_type": "channel"
+    },
+    "type": "event_callback",
+    "event_id": "EvXXXXXX",
+    "event_time": 1559841923,
+    "authed_users": ["UXXXXXXXX", "UXXXXXXXX"]
+  }
 }


### PR DESCRIPTION
- Change simulation templates to match a complete incoming slack event and not just the event parameter.
- Parse incoming message for guests correctly. Was not realizing that when the event is an `app_mention` a first word corresponding to the bot id is added to the text parameter.
- If an announcement that was today but in the past was added it would be appended to the list, so fixed that by adding another datetime function.