### PR TITLE
Update graphql schema for widget querying

### DIFF
--- a/app/graphql/helios2_schema.rb
+++ b/app/graphql/helios2_schema.rb
@@ -4,4 +4,6 @@ class Helios2Schema < GraphQL::Schema
   mutation(Types::MutationType)
   query(Types::QueryType)
   subscription(Types::SubscriptionType)
+
+  orphan_types [Types::GuestsWidget, Types::WeatherWidget, Types::TwitterWidget, Types::NumbersWidget]
 end

--- a/app/graphql/types/base_interface.rb
+++ b/app/graphql/types/base_interface.rb
@@ -1,0 +1,3 @@
+module Types::BaseInterface
+  include GraphQL::Schema::Interface
+end

--- a/app/graphql/types/location_type.rb
+++ b/app/graphql/types/location_type.rb
@@ -9,6 +9,8 @@ class Types::LocationType < Types::BaseObject
   field "is_primary", Boolean, method: :primary?
   field "weather", Types::WeatherType
   field "day_announcements", [Types::AnnouncementType]
+  field "widgets", Types::WidgetCollectionType
+
   field "wifi_name", String
   field "wifi_password", String
   field "bathroom_code", String

--- a/app/graphql/types/widget_collection_type.rb
+++ b/app/graphql/types/widget_collection_type.rb
@@ -1,0 +1,14 @@
+class Types::WidgetCollectionType < Types::BaseObject
+  field :enabled, [Types::WidgetType]
+  field :next, Types::WidgetType do
+    argument :current_widget_id, Integer, required: false
+  end
+
+  def enabled
+    object.enabled.all
+  end
+
+  def next(current_widget_id: nil)
+    object.enabled.next_or_default(current_widget_id)
+  end
+end

--- a/app/graphql/types/widget_type.rb
+++ b/app/graphql/types/widget_type.rb
@@ -1,0 +1,77 @@
+module Types::WidgetType
+  include Types::BaseInterface
+
+  description "A single tab or panel of Helios"
+  graphql_name "Widget"
+
+  field "id", Integer, null: false
+  field "name", String, null: false
+  field "duration_seconds", Integer, null: false
+  field "position", Integer, null: false
+  field "location_id", String, null: false
+
+  definition_methods do
+    def resolve_type(obj, _ctx)
+      case obj.name
+      when 'Guests' then Types::GuestsWidget
+      when 'Weather' then Types::WeatherWidget
+      when 'Twitter' then Types::TwitterWidget
+      when 'Numbers' then Types::NumbersWidget
+      else raise "Unexpected WidgetType: #{obj.inspect}"
+      end
+    end
+  end
+end
+
+class Types::GuestsWidget < Types::BaseObject
+  implements Types::WidgetType
+
+  field "day_announcements", [Types::AnnouncementType] do
+    description "MojoTech announcements today"
+  end
+
+  def day_announcements
+    Announcement.happen_today(object.location.time_zone)
+  end
+end
+
+class Types::WeatherWidget < Types::BaseObject
+  implements Types::WidgetType
+
+  field :weather, Types::WeatherType do
+    description "Weather response from Dark Sky"
+  end
+
+  def weather
+    object.location.weather
+  end
+end
+
+class Types::TwitterWidget < Types::BaseObject
+  implements Types::WidgetType
+
+  field :tweets, [Types::TweetType] do
+    description "Tweets from MojoTech"
+  end
+
+  def tweets
+    Clients::TwitterClient.latest_tweets
+  end
+end
+
+class Types::NumbersWidget < Types::BaseObject
+  implements Types::WidgetType
+
+  field :events, Types::EventCollectionType do
+    description "MojoTech slack/github events"
+    argument :after, String, required: false
+    argument :type, Types::EventSourceType, required: false
+  end
+
+  def events(after: nil, type: nil)
+    events = Event.all
+    events = events.created_after(after) if after
+    events = events.with_source(type) if type
+    events
+  end
+end

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -353,6 +353,24 @@
               "deprecationReason": null
             },
             {
+              "name": "widgets",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WidgetCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "wifiName",
               "description": null,
               "args": [
@@ -2374,6 +2392,194 @@
         },
         {
           "kind": "OBJECT",
+          "name": "WidgetCollection",
+          "description": null,
+          "fields": [
+            {
+              "name": "enabled",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INTERFACE",
+                      "name": "Widget",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "next",
+              "description": null,
+              "args": [
+                {
+                  "name": "currentWidgetId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Widget",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Widget",
+          "description": "A single tab or panel of Helios",
+          "fields": [
+            {
+              "name": "durationSeconds",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locationId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "position",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "GuestsWidget",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "NumbersWidget",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "TwitterWidget",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "WeatherWidget",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
           "name": "TrafficCam",
           "description": null,
           "fields": [
@@ -4008,6 +4214,541 @@
               "deprecationReason": null
             }
           ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "GuestsWidget",
+          "description": null,
+          "fields": [
+            {
+              "name": "dayAnnouncements",
+              "description": "MojoTech announcements today",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Announcement",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "durationSeconds",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locationId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "position",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Widget",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "WeatherWidget",
+          "description": null,
+          "fields": [
+            {
+              "name": "durationSeconds",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locationId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "position",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "weather",
+              "description": "Weather response from Dark Sky",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Weather",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Widget",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TwitterWidget",
+          "description": null,
+          "fields": [
+            {
+              "name": "durationSeconds",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locationId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "position",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tweets",
+              "description": "Tweets from MojoTech",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "MojoTweet",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Widget",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "NumbersWidget",
+          "description": null,
+          "fields": [
+            {
+              "name": "durationSeconds",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "events",
+              "description": "MojoTech slack/github events",
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "type",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "EventSource",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "EventCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locationId",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "position",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Widget",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
           "possibleTypes": null
         }
       ],

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -7,6 +7,7 @@ class Location < ApplicationRecord
   has_many :announcements, inverse_of: :location, dependent: :destroy
   has_many :solarcycles, dependent: :destroy
   has_many :traffic_cams, dependent: :destroy
+  has_many :widgets, dependent: :destroy
 
   def self.primary(city_name = ENV['PRIMARY_CITY_NAME'])
     find_by(city_name: city_name)

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -2,6 +2,8 @@ class Widget < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   validates :position, presence: true, uniqueness: true
 
+  belongs_to :location
+
   default_scope { order(position: :asc) }
   scope :enabled, -> { where(enabled: true) }
 end

--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -6,4 +6,8 @@ class Widget < ApplicationRecord
 
   default_scope { order(position: :asc) }
   scope :enabled, -> { where(enabled: true) }
+
+  def self.next_or_default(current_id)
+    current_id && where('id > ?', current_id).order(:position).first || first
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_23_182602) do
+ActiveRecord::Schema.define(version: 2019_08_23_192258) do
 
   create_table "announcements", force: :cascade do |t|
     t.datetime "publish_on", null: false
@@ -74,6 +74,8 @@ ActiveRecord::Schema.define(version: 2019_08_23_182602) do
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "location_id"
+    t.index ["location_id"], name: "index_widgets_on_location_id"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,28 +30,32 @@ Widget.create(
   name: "Guests",
   enabled: false,
   duration_seconds: 20,
-  position: 0
+  position: 0,
+  location_id: Location.find_by(city_name: ENV['PRIMARY_CITY_NAME']).id
 )
 
 Widget.create(
   name: "Weather",
   enabled: true,
   duration_seconds: 20,
-  position: 1
+  position: 1,
+  location_id: Location.find_by(city_name: ENV['PRIMARY_CITY_NAME']).id
 )
 
 Widget.create(
   name: "Twitter",
-  enabled: true,
+  enabled: false,
   duration_seconds: 20,
-  position: 2
+  position: 2,
+  location_id: Location.find_by(city_name: ENV['PRIMARY_CITY_NAME']).id
 )
 
 Widget.create(
   name: "Numbers",
   enabled: true,
   duration_seconds: 20,
-  position: 3
+  position: 3,
+  location_id: Location.find_by(city_name: ENV['PRIMARY_CITY_NAME']).id
 )
 
 TrafficCam.create(

--- a/schema.graphql
+++ b/schema.graphql
@@ -39,6 +39,16 @@ enum EventSource {
   slackMessage
 }
 
+type GuestsWidget implements Widget {
+  # MojoTech announcements today
+  dayAnnouncements: [Announcement!]!
+  durationSeconds: Int!
+  id: Int!
+  locationId: String!
+  name: String!
+  position: Int!
+}
+
 type Location {
   bathroomCode: String!
   cityName: String!
@@ -50,6 +60,7 @@ type Location {
   timezone: String!
   trafficCams: [TrafficCam!]!
   weather: Weather!
+  widgets: WidgetCollection!
   wifiName: String!
   wifiPassword: String!
 }
@@ -65,6 +76,17 @@ type MojoTweet {
 
 type Mutation {
   testField: String!
+}
+
+type NumbersWidget implements Widget {
+  durationSeconds: Int!
+
+  # MojoTech slack/github events
+  events(after: String, type: EventSource): EventCollection!
+  id: Int!
+  locationId: String!
+  name: String!
+  position: Int!
 }
 
 type Query {
@@ -117,6 +139,17 @@ type TweetUser {
   avatar: String!
   handle: String!
   name: String!
+}
+
+type TwitterWidget implements Widget {
+  durationSeconds: Int!
+  id: Int!
+  locationId: String!
+  name: String!
+  position: Int!
+
+  # Tweets from MojoTech
+  tweets: [MojoTweet!]!
 }
 
 scalar UTCDateTime
@@ -234,4 +267,29 @@ type WeatherMinutelyDetail {
   data: [WeatherMinutelyData!]!
   icon: String!
   summary: String!
+}
+
+type WeatherWidget implements Widget {
+  durationSeconds: Int!
+  id: Int!
+  locationId: String!
+  name: String!
+  position: Int!
+
+  # Weather response from Dark Sky
+  weather: Weather!
+}
+
+# A single tab or panel of Helios
+interface Widget {
+  durationSeconds: Int!
+  id: Int!
+  locationId: String!
+  name: String!
+  position: Int!
+}
+
+type WidgetCollection {
+  enabled: [Widget!]!
+  next(currentWidgetId: Int): Widget!
 }

--- a/spec/models/solarcycle_spec.rb
+++ b/spec/models/solarcycle_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Solarcycle, type: :model do
   before do
     Timecop.freeze(Time.new(2019, 6, 16, 6, 0, 0, "-04:00"))
 
+    Location.delete_all
     Solarcycle.delete_all
     location = Location.create!(
       latitude: 40.7127,

--- a/spec/models/widget_spec.rb
+++ b/spec/models/widget_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe Widget, type: :model do
+  Location.delete_all
+  loc = Location.create(
+    latitude: 41.823989,
+    longitude: -71.412834,
+    city_name: 'Providence',
+    time_zone: 'America/New_York'
+  )
+
+  Widget.delete_all
+  guests = Widget.create(
+    name: "Guests",
+    enabled: false,
+    duration_seconds: 20,
+    position: 0,
+    location_id: loc.id
+  )
+
+  weather = Widget.create(
+    name: "Weather",
+    enabled: true,
+    duration_seconds: 20,
+    position: 1,
+    location_id: loc.id
+  )
+
+  twitter = Widget.create(
+    name: "Twitter",
+    enabled: false,
+    duration_seconds: 20,
+    position: 2,
+    location_id: loc.id
+  )
+
+  numbers = Widget.create(
+    name: "Numbers",
+    enabled: true,
+    duration_seconds: 20,
+    position: 3,
+    location_id: loc.id
+  )
+
+  it "returns next widget" do
+    expect(Widget.next_or_default(weather[:id])).to eq(twitter)
+    expect(Widget.next_or_default(numbers[:id])).to eq(guests)
+    expect(Widget.next_or_default(guests[:id])).to eq(weather)
+
+    expect(Widget.next_or_default(twitter[:id])).to eq(numbers)
+    expect(Widget.next_or_default(nil)).to eq(guests)
+  end
+
+  it "returns next enabled widget" do
+    expect(Widget.enabled.next_or_default(weather[:id])).to eq(numbers)
+    expect(Widget.enabled.next_or_default(numbers[:id])).to eq(weather)
+    expect(Widget.enabled.next_or_default(guests[:id])).to eq(weather)
+
+    expect(Widget.enabled.next_or_default(twitter[:id])).to eq(numbers)
+    expect(Widget.enabled.next_or_default(nil)).to eq(weather)
+  end
+
+  it "returns array of enabled widgets" do
+    enabled_widgets = [weather, numbers]
+    expect(Widget.enabled).to eq(enabled_widgets)
+  end
+end


### PR DESCRIPTION
- Created a `Widget` graphql interface to be used in the frontend to do a single query to get all `Weather`, `Guests`, `Numbers` and `Twitter` information for a given location
- Example query and result: 
![Screen Shot 2019-06-11 at 4 22 41 PM](https://user-images.githubusercontent.com/30034042/59303887-2dd48a00-8c65-11e9-81d9-4f6d459491ca.png)
- Eventually all existing queries in the frontend could be replaced with a single query like this, and some graphql query type definitions might become unnecessary 
