### PR TITLE
feature: add count arg to simulate PR/slack

### DIFF
--- a/lib/tasks/simulate.rake
+++ b/lib/tasks/simulate.rake
@@ -2,11 +2,13 @@ namespace :simulate do
   desc "Simulates opening a new pull request on github"
   task pull_request: :environment do
     post_github_event('pull_request', render_new_pull_request_json)
+    disable_github_authentication
   end
 
   desc "Simulates a new commit on github"
   task :commit, [:count] => :environment do |_t, args|
     args.with_defaults(count: 1)
+    disable_github_authentication
     post_github_event('push', render_new_push_json(args[:count].to_i))
   end
 
@@ -25,7 +27,6 @@ namespace :simulate do
   end
 
   def post_github_event(event, params)
-    disable_github_authentication
     session = ActionDispatch::Integration::Session.new(Rails.application)
     resp = session.post(
       "/web_hooks/github",

--- a/lib/tasks/simulate.rake
+++ b/lib/tasks/simulate.rake
@@ -1,8 +1,10 @@
 namespace :simulate do
   desc "Simulates opening a new pull request on github"
-  task pull_request: :environment do
+  task :pull_request, [:count] => :environment do |_t, args|
     post_github_event('pull_request', render_new_pull_request_json)
     disable_github_authentication
+    args.with_defaults(count: 1)
+    args[:count].to_i.times { post_github_event('pull_request', render_new_pull_request_json) }
   end
 
   desc "Simulates a new commit on github"
@@ -13,8 +15,9 @@ namespace :simulate do
   end
 
   desc "Simulates a new message on Slack"
-  task slack_message: :environment do
-    post_slack_event(render_new_slack_message_json)
+  task :slack_message, [:count] => :environment do |_t, args|
+    args.with_defaults(count: 1)
+    args[:count].to_i.times { post_slack_event(render_new_slack_message_json) }
   end
 
   desc "Simulates a new announcement on Slack"


### PR DESCRIPTION
Adds `rake simulate:pull_request[COUNT]` and `rake simulate:slack_message[COUNT]`