### PR TITLE
fix: intervals now clear

### DIFF
--- a/app/javascript/components/date.jsx
+++ b/app/javascript/components/date.jsx
@@ -39,6 +39,12 @@ export class Date extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+    }
+  }
+
   setDate = () => {
     this.setState({ date: dateForTimezone(this.timezone(this.props)) });
   };
@@ -48,7 +54,7 @@ export class Date extends React.Component {
 
   startDateTimer = () => {
     this.setDate();
-    setInterval(this.setDate, 10000);
+    this.intervalId = setInterval(this.setDate, 10000);
   };
 
   render() {

--- a/app/javascript/components/time.jsx
+++ b/app/javascript/components/time.jsx
@@ -58,9 +58,15 @@ export class Time extends React.Component {
   }
 
   componentDidMount() {
-    setInterval(() => {
+    this.intervalId = setInterval(() => {
       this.setState({ time: timeForTimezone(this.props.timezone) });
     }, 10000);
+  }
+
+  componentWillUnmount() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+    }
   }
 
   render() {


### PR DESCRIPTION
Date and time have a setInterval that previously was not cleared on dismount. This would produce a memory leak if they were dismounted.