### PR TITLE
fix: remove bad Column styling 

### DIFF
--- a/app/javascript/components/widgets/messages/message.jsx
+++ b/app/javascript/components/widgets/messages/message.jsx
@@ -19,9 +19,6 @@ const MessageDisplay = styled(GreySubText)`
 const Column = styled.div`
   display: flex;
   flex-direction: column;
-  margin-top: 100px
-  margin-bottom: 500px
-  height: 100%;
 `;
 
 const Message = ({ width, height, message, imageWidth, imageHeight }) => {


### PR DESCRIPTION
Message used to rely on margins to center itself, which caused problems, especially
on the guest tab. Now it uses the screen height to center itself.