### PR TITLE
fix: move solar cycles into weather

### DIFF
--- a/app/graphql/types/location_type.rb
+++ b/app/graphql/types/location_type.rb
@@ -9,7 +9,6 @@ class Types::LocationType < Types::BaseObject
   field "is_primary", Boolean, method: :primary?
   field "weather", Types::WeatherType
   field "day_announcements", [Types::AnnouncementType]
-  field "solarcycles", [Types::SolarcycleType]
   field "wifi_name", String
   field "wifi_password", String
   field "bathroom_code", String

--- a/app/graphql/types/weather_type.rb
+++ b/app/graphql/types/weather_type.rb
@@ -119,6 +119,7 @@ class Types::WeatherType < Types::WeatherObject
   field "hourly", Types::WeatherHourlyDetailType
   field "daily", Types::WeatherDailyDetailType
   field "offset", Int
+  field "solarcycles", [Types::SolarcycleType]
 
   # field "flags", # TODO: skipping this for now
 end

--- a/app/javascript/components/widgets/weather/panel.jsx
+++ b/app/javascript/components/widgets/weather/panel.jsx
@@ -89,7 +89,6 @@ const subscribeWeatherPublished = gql`
       ...HourlyWeather
       ...MinutelyWeather
       ...DailyWeather
-      ...SunriseSunsetLocation
       ...SunriseSunsetWeather
     }
   }
@@ -98,7 +97,6 @@ const subscribeWeatherPublished = gql`
   ${HourlyTemps.fragments.weather}
   ${MinutelyWeather.fragments.weather}
   ${DailyWeather.fragments.weather}
-  ${SunriseSunset.fragments.location}
   ${SunriseSunset.fragments.weather}
 `;
 

--- a/app/javascript/components/widgets/weather/sunrise-sunset.jsx
+++ b/app/javascript/components/widgets/weather/sunrise-sunset.jsx
@@ -51,16 +51,6 @@ const SunsetLabel = styled.div`
   z-index: 2;
 `;
 
-const getSunriseSunsetLocation = gql`
-  fragment SunriseSunsetLocation on Location {
-    timezone
-    solarcycles {
-      type
-      time
-    }
-  }
-`;
-
 const getSunriseSunsetWeather = gql`
   fragment SunriseSunsetWeather on Weather {
     daily {
@@ -68,11 +58,22 @@ const getSunriseSunsetWeather = gql`
         moonPhase
       }
     }
+    solarcycles {
+      type
+      time
+    }
+  }
+`;
+
+const getSunriseSunsetLocation = gql`
+  fragment SunriseSunsetLocation on Location {
+    timezone
   }
 `;
 
 const SunriseSunset = ({ location, weather }) => {
-  const { timezone, solarcycles } = location;
+  const { timezone } = location;
+  const { solarcycles } = weather;
   const currDate = new Date();
 
   const [beforeNow, afterNow] = splitWhen(
@@ -134,8 +135,8 @@ SunriseSunset.propTypes = {
 };
 
 SunriseSunset.fragments = {
-  location: getSunriseSunsetLocation,
   weather: getSunriseSunsetWeather,
+  location: getSunriseSunsetLocation,
 };
 
 export default withFragment(SunriseSunset);

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -116,39 +116,177 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Location",
+          "description": null,
+          "fields": [
+            {
+              "name": "bathroomCode",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cityName",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dayAnnouncements",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Announcement",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isPrimary",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "latitude",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "longitude",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "timezone",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             },
             {
               "name": "weather",
-              "description": "Weather response from Dark Sky",
+              "description": null,
               "args": [
-                {
-                  "name": "latitude",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Float",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "longitude",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Float",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
+
               ],
               "type": {
                 "kind": "NON_NULL",
@@ -161,12 +299,68 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "wifiName",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "wifiPassword",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
           "interfaces": [
 
           ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": "Represents a unique identifier that is Base64 obfuscated. It is often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"VXNlci0xMA==\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "Represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -302,6 +496,32 @@
               "deprecationReason": null
             },
             {
+              "name": "solarcycles",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "SolarCycle",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "timezone",
               "description": null,
               "args": [
@@ -324,16 +544,6 @@
           "interfaces": [
 
           ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Float",
-          "description": "Represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -1914,11 +2124,11 @@
         },
         {
           "kind": "OBJECT",
-          "name": "Location",
+          "name": "SolarCycle",
           "description": null,
           "fields": [
             {
-              "name": "bathroomCode",
+              "name": "time",
               "description": null,
               "args": [
 
@@ -1936,203 +2146,7 @@
               "deprecationReason": null
             },
             {
-              "name": "cityName",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "dayAnnouncements",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "Announcement",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "id",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "isPrimary",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "latitude",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "longitude",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "solarcycles",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "SolarCycle",
-                      "ofType": null
-                    }
-                  }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "timezone",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "weather",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Weather",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "wifiName",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "wifiPassword",
+              "name": "type",
               "description": null,
               "args": [
 
@@ -2154,16 +2168,6 @@
           "interfaces": [
 
           ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "ID",
-          "description": "Represents a unique identifier that is Base64 obfuscated. It is often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"VXNlci0xMA==\"`) or integer (such as `4`) input value will be accepted as an ID.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -2313,55 +2317,6 @@
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "SolarCycle",
-          "description": null,
-          "fields": [
-            {
-              "name": "time",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "UnixDateTime",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "type",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-
-          ],
           "enumValues": null,
           "possibleTypes": null
         },

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -5,13 +5,17 @@ class Location < ApplicationRecord
   validates :time_zone, presence: true
 
   has_many :announcements, inverse_of: :location, dependent: :destroy
+  has_many :solarcycles, dependent: :destroy
 
   def self.primary(city_name = ENV['PRIMARY_CITY_NAME'])
     find_by(city_name: city_name)
   end
 
   def weather
-    Clients::DarkskyClient.forecast(self)
+    response = Clients::DarkskyClient.forecast(self).dup
+    response['solarcycles'] = solarcycles
+    response.freeze
+    response
   end
 
   def day_announcements
@@ -33,6 +37,4 @@ class Location < ApplicationRecord
   def bathroom_code
     ENV['BATHROOM_CODE']
   end
-
-  has_many :solarcycles, dependent: :destroy
 end

--- a/app/workers/weather_poller_worker.rb
+++ b/app/workers/weather_poller_worker.rb
@@ -31,11 +31,11 @@ class WeatherPollerWorker
   def poll(location)
     logger.info "Polling #{location.latitude} #{location.longitude}"
     location_record = Location.where(latitude: location.latitude, longitude: location.longitude).first
-    get_forecast(location_record, location)
+    get_forecast(location_record)
   end
 
-  def get_forecast(record, location)
-    data = Clients::DarkskyClient.forecast(record)
+  def get_forecast(location)
+    data = location.weather
     Helios2Schema.subscriptions.trigger(
       "weatherPublished",
       { latitude: location.latitude.to_f, longitude: location.longitude.to_f },

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,15 +49,6 @@ ActiveRecord::Schema.define(version: 2019_06_04_172236) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "widgets", force: :cascade do |t|
-    t.string "name", null: false
-    t.boolean "enabled", null: false
-    t.integer "duration_seconds", null: false
-    t.integer "position", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end 
-    
   create_table "solarcycles", force: :cascade do |t|
     t.string "type", null: false
     t.string "time", null: false
@@ -65,6 +56,15 @@ ActiveRecord::Schema.define(version: 2019_06_04_172236) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["location_id"], name: "index_solarcycles_on_location_id"
+  end
+
+  create_table "widgets", force: :cascade do |t|
+    t.string "name", null: false
+    t.boolean "enabled", null: false
+    t.integer "duration_seconds", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,3 +1,13 @@
+type Announcement {
+  announcementId: String!
+  company: String!
+  id: ID!
+  locationId: String!
+  message: String!
+  people: String!
+  publishOn: UTCDateTime!
+}
+
 type Event {
   createdAt: String!
   externalId: String!
@@ -30,11 +40,11 @@ enum EventSource {
 type Location {
   bathroomCode: String!
   cityName: String!
+  dayAnnouncements: [Announcement!]!
   id: ID!
   isPrimary: Boolean!
   latitude: Float!
   longitude: Float!
-  solarcycles: [SolarCycle!]!
   timezone: String!
   weather: Weather!
   wifiName: String!
@@ -62,12 +72,17 @@ type SolarCycle {
 }
 
 type Subscription {
+  # An announcement was published
+  announcementPublished: Announcement!
+
   # An event was published to the API
   eventPublished: Event!
 
   # Latest weather data retrieved
   weatherPublished(latitude: Float!, longitude: Float!): Weather!
 }
+
+scalar UTCDateTime
 
 scalar UnixDateTime
 
@@ -79,6 +94,7 @@ type Weather {
   longitude: Float!
   minutely: WeatherMinutelyDetail!
   offset: Int!
+  solarcycles: [SolarCycle!]!
   timezone: String!
 }
 

--- a/spec/workers/weather_poller_worker_spec.rb
+++ b/spec/workers/weather_poller_worker_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe WeatherPollerWorker, type: :worker do
         receive(:trigger).with(
           "weatherPublished",
           { latitude: 41.823989, longitude: -71.412834 },
-          TESTDATA
+          hash_including(TESTDATA)
         )
       )
       WeatherPollerWorker.new.poll(WeatherPollerWorker::LocationParams.new("41.823989", "-71.412834"))


### PR DESCRIPTION
weather is currently published without any location data so it is
invalid graphql to query solarcycles from the weather published event.
the location query in our subscription is causing the endpoint to fail.
major issues:
* our eslint plugin does not detect incorrect fragment
* subscription query failures do not provide an error