### PR TITLE
fix: address issue with solarcycle proxy class not working with graphql and limit solarycycles to after yesterday

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'
+  gem 'timecop'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timecop (0.9.1)
     timers (4.0.4)
       hitimes
     turbolinks (5.1.1)
@@ -323,6 +324,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
+  timecop
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -13,7 +13,7 @@ class Location < ApplicationRecord
 
   def weather
     response = Clients::DarkskyClient.forecast(self).dup
-    response['solarcycles'] = solarcycles
+    response['solarcycles'] = solarcycles.all.to_a
     response.freeze
     response
   end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -13,7 +13,7 @@ class Location < ApplicationRecord
 
   def weather
     response = Clients::DarkskyClient.forecast(self).dup
-    response['solarcycles'] = solarcycles.all.to_a
+    response['solarcycles'] = solarcycles.after_beginning_of_yesterday.to_a
     response.freeze
     response
   end

--- a/app/models/solarcycle.rb
+++ b/app/models/solarcycle.rb
@@ -1,4 +1,6 @@
 class Solarcycle < ApplicationRecord
   self.inheritance_column = :_type_disabled
   belongs_to :location
+
+  scope :after_beginning_of_yesterday, -> { where('time > ?', 1.day.ago.beginning_of_day) }
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+module WeatherHelpers
+  def self.darksky_response
+    text = File.read(Rails.root.join("spec", "fixtures", "files", "darksky_response_1.json"))
+    json = JSON.parse(text)
+    Hashie::Mash.new(json)
+  end
+end
+
+RSpec.describe Solarcycle, type: :model do
+  before do
+    Location.delete_all
+    Location.create!(
+      latitude: 40.7127,
+      longitude: -74.0059,
+      city_name: 'Providence',
+      time_zone: 'America/New_York'
+    )
+    allow(ForecastIO).to receive(:forecast) { WeatherHelpers.darksky_response }
+  end
+
+  after do
+    Timecop.return
+  end
+
+  it "should have a weather response" do
+    weather = Location.first.weather
+    expect(weather).to_not be_nil
+  end
+end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -27,5 +27,6 @@ RSpec.describe Solarcycle, type: :model do
   it "should have a weather response" do
     weather = Location.first.weather
     expect(weather).to_not be_nil
+    expect(weather['solarcycles']).to be_a(Array)
   end
 end

--- a/spec/models/solarcycle_spec.rb
+++ b/spec/models/solarcycle_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Solarcycle, type: :model do
+  before do
+    Timecop.freeze(Time.new(2019, 6, 16, 6, 0, 0, "-04:00"))
+
+    Solarcycle.delete_all
+    location = Location.create!(
+      latitude: 40.7127,
+      longitude: -74.0059,
+      city_name: 'Providence',
+      time_zone: 'America/New_York'
+    )
+    location.solarcycles.create!(
+      type: 'sunrise',
+      time: '2019-06-14T05:11:31-04:00'
+    )
+    location.solarcycles.create!(
+      type: 'sunset',
+      time: '2019-06-15T05:11:31-04:00'
+    )
+    location.solarcycles.create!(
+      type: 'sunrise',
+      time: '2019-06-16T05:11:31-04:00'
+    )
+  end
+
+  after do
+    Timecop.return
+  end
+
+  it "should limit cycles to after beginning of yesterday" do
+    expect(Solarcycle.after_beginning_of_yesterday.count).to eq(2)
+  end
+end


### PR DESCRIPTION
address issue with solarcycle proxy class not working with graphql and limit solarycycles to after yesterday