### PR TITLE
Remove Scrollbar from Numbers

### DIFF
--- a/app/javascript/components/widgets/numbers/falling-blocks.jsx
+++ b/app/javascript/components/widgets/numbers/falling-blocks.jsx
@@ -207,7 +207,7 @@ class Scene extends React.Component {
     return (
       <div
         style={{
-          position: 'absolute',
+          position: 'fixed',
           top: 0,
           left: 0,
         }}


### PR DESCRIPTION
Changing the position from absolute to fixed prevents the vertical scrollbar from appear on the Numbers panel