### PR TITLE
Scrollbar Fixes

### DIFF
--- a/app/javascript/components/live-stream.jsx
+++ b/app/javascript/components/live-stream.jsx
@@ -1,6 +1,3 @@
-import React from 'react';
-import Wrapper from '@components/panel-wrapper';
-
-export const Live = () => <Wrapper />;
+export const Live = () => null;
 
 export default Live;

--- a/app/javascript/components/panel-wrapper.jsx
+++ b/app/javascript/components/panel-wrapper.jsx
@@ -3,9 +3,11 @@ import { colors } from '@lib/theme';
 
 export const Wrapper = styled.div`
   background: ${colors.black};
-  height: calc(100vh - 200px);
-  padding: 100px;
-  width: calc(100vw - 200px);
+  height: calc(100vh - 100px);
+  padding-top: 100px;
+  padding-left: 100px;
+  width: calc(100vw - 100px);
+  overflow: hidden;
 `;
 
 export default Wrapper;

--- a/app/javascript/components/side-panel.jsx
+++ b/app/javascript/components/side-panel.jsx
@@ -11,6 +11,7 @@ const Wrapper = styled.div`
   padding: ${spacing.xxxl};
   top: 0;
   width: 600px;
+  overflow: hidden;
 `;
 
 export const SidePanel = ({ widgets, selectedWidget }) => (

--- a/app/javascript/components/twitter.jsx
+++ b/app/javascript/components/twitter.jsx
@@ -1,6 +1,3 @@
-import React from 'react';
-import Wrapper from '@components/panel-wrapper';
-
-export const Twitter = () => <Wrapper />;
+export const Twitter = () => null;
 
 export default Twitter;

--- a/app/javascript/components/widgets/numbers/falling-blocks.jsx
+++ b/app/javascript/components/widgets/numbers/falling-blocks.jsx
@@ -207,7 +207,7 @@ class Scene extends React.Component {
     return (
       <div
         style={{
-          position: 'absolute',
+          position: 'fixed',
           top: 0,
           left: 0,
         }}

--- a/app/javascript/components/widgets/weather/daily-weather.jsx
+++ b/app/javascript/components/widgets/weather/daily-weather.jsx
@@ -14,7 +14,6 @@ const Wrapper = styled(Row)`
   color: ${colors.grey};
   font-weight: ${weights.light};
   margin-left: ${spacing.xl};
-  margin-top: 65px;
 `;
 
 const Item = styled.div`

--- a/app/javascript/components/widgets/weather/panel.jsx
+++ b/app/javascript/components/widgets/weather/panel.jsx
@@ -31,7 +31,6 @@ const Column = styled.div`
 const CenteredRow = styled(Row)`
   align-items: center;
   margin-left: 50px;
-  margn-top: ${spacing.m};
 `;
 
 const TempText = styled.div`
@@ -45,7 +44,6 @@ const TempText = styled.div`
 const SummaryText = styled(WhiteText)`
   font-size: ${fontSizes.large};
   font-weight: ${weights.regular};
-  margin-top: 50px;
   width: ${leftPanelWidth};
   text-align: center;
   font-family: ${fonts.light};
@@ -53,7 +51,6 @@ const SummaryText = styled(WhiteText)`
 
 const Notice = styled(GreySubText)`
   font-size: ${fontSizes.tiny};
-  margin-top: 80px;
   text-align: center;
   width: ${leftPanelWidth};
 `;

--- a/app/javascript/components/widgets/weather/sunrise-sunset.jsx
+++ b/app/javascript/components/widgets/weather/sunrise-sunset.jsx
@@ -18,7 +18,6 @@ import SemiCircle from '@weather/semi-circle';
 const containerHeight = '344px';
 
 const SunriseSunsetContainer = styled.div`
-  margin-top: ${spacing.xxl};
   width: ${leftPanelWidth};
   height: ${containerHeight};
   position: relative;


### PR DESCRIPTION
Fixes scrollbar issues surrounding weather, twitter, live-stream and numbers.

Weather panel's scrollbar problems were fixed by properly resizing the panel components so they correctly moved in relation to the screen size. By having a smaller screen size, the components will get closer together to fit, or grow further apart as the screen height increases.

Live-stream and Twitter were getting using Wrapper twice. Those two are currently placeholders, so having them export null seems appropriate.

Numbers was creating a scrollbar with its absolute positioning. Changing its positioning to fixed solves the scrollbar issue.