### PR TITLE
feat: add transparent background

### DIFF
--- a/app/javascript/components/side-panel.jsx
+++ b/app/javascript/components/side-panel.jsx
@@ -12,6 +12,7 @@ const Wrapper = styled.div`
   top: 0;
   width: 600px;
   overflow: hidden;
+  background-color: rgba(0, 0, 0, 0.7);
 `;
 
 export const SidePanel = ({ widgets, selectedWidget }) => (


### PR DESCRIPTION
The side panel now has a transparent background so its elements are still visible even with blocks behind it.
![Screen Shot 2019-06-21 at 10 10 39 AM](https://user-images.githubusercontent.com/48894331/59928495-e12f4280-940c-11e9-81f9-fde077f297b2.png)

