### PR TITLE
fix: remove blocks when counts are reset

### DIFF
--- a/app/javascript/components/widgets/numbers/falling-blocks.jsx
+++ b/app/javascript/components/widgets/numbers/falling-blocks.jsx
@@ -83,7 +83,17 @@ class Scene extends React.Component {
     const { world } = this.getLocalState(this.props);
     if (world) {
       const loadedWorld = this.res.resurrect(world);
-      Engine.merge(this.engine, { world: loadedWorld });
+      const counts = this.getCountsFromProps(this.props);
+
+      if (
+        this.state.githubCommit <= counts.githubCommit &&
+        this.state.githubPull <= counts.githubPull &&
+        this.state.slackMessage <= counts.slackMessage
+      ) {
+        Engine.merge(this.engine, { world: loadedWorld });
+      } else {
+        this.setState({ githubCommit: 0, githubPull: 0, slackMessage: 0 });
+      }
     }
     Composite.allBodies(this.engine.world)
       .filter(body => !body.isStatic)


### PR DESCRIPTION
The blocks would remain, even if the counts were reset. To account for this, we can refuse to merge with the saved world if the amount of blocks is greater than the count. We also need to reset the state of githubCommit, githubPull and slackMessages to 0, to prevent the saved state from being greater than the count. 