### PR TITLE
improve styling for hourly-weather

### DIFF
--- a/app/javascript/components/widgets/weather/hourly-temps.jsx
+++ b/app/javascript/components/widgets/weather/hourly-temps.jsx
@@ -20,6 +20,7 @@ const opacities = {
 const Wrapper = styled(Row)`
   color: ${colors.white};
   margin-left: ${spacing.xxxl};
+  margin-top: 15px;
 `;
 
 const Item = styled.div`
@@ -30,25 +31,25 @@ const Item = styled.div`
 `;
 
 const Time = styled.div`
-  font-size: ${fontSizes.tiny};
+  font-size: ${fontSizes.small};
   font-family: ${fonts.regular};
   font-weight: ${weights.regular};
   letter-spacing: 1.4px;
 `;
 
 const Temp = styled.div`
-  font-size: ${fontSizes.large};
+  font-size: 48px;
   font-family: ${fonts.extended};
   margin: ${spacing.xs} 0;
 `;
 
 const Precip = styled.div`
-  font-size: ${fontSizes.tiny};
+  font-size: ${fontSizes.small};
   font-family: ${fonts.regular};
 `;
 
 const Percent = styled.span`
-  font-size: ${fontSizes.micro};
+  font-size: ${fontSizes.tiny};
 `;
 
 const RainIcon = styled.img`
@@ -78,7 +79,7 @@ const HourlyTemps = ({ weather }) => {
             <Time>{parseHour(time)}</Time>
             <Temp>{parseInt(temperature, 10)}°</Temp>
             <Precip>
-              <RainIcon src={rainIcon} width="16" height="16" alt="" />
+              <RainIcon src={rainIcon} width="20" height="20" alt="" />
               {parseInt(precipProbability * 100, 10)}
               <Percent>%</Percent>
             </Precip>


### PR DESCRIPTION
At Ivan's request, I changed the styling for hourly-weather to be a bit bigger and readable, as well as more centered. It looks a lot better now!

![Screen Shot 2019-07-10 at 4 28 15 PM](https://user-images.githubusercontent.com/48894331/61003063-04c11b00-a331-11e9-8ff2-9f11c646a3f7.png)
