### PR TITLE
Livestream Panel

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -8,3 +8,4 @@ SLACK_API_SECRET=
 SLACK_REDIRECT_URI=https://mojotech-helios2.herokuapp.com/web_hooks/create_slack_auth
 SLACK_VERIFICATION_TOKEN=
 SLACK_WEBHOOK_URL=
+YOUTUBE_LIVESTREAM_URL=

--- a/app/graphql/types/location_type.rb
+++ b/app/graphql/types/location_type.rb
@@ -12,4 +12,5 @@ class Types::LocationType < Types::BaseObject
   field "wifi_name", String
   field "wifi_password", String
   field "bathroom_code", String
+  field "livestream_url", String
 end

--- a/app/javascript/components/widget-controller.jsx
+++ b/app/javascript/components/widget-controller.jsx
@@ -6,6 +6,7 @@ import SidePanel from '@components/side-panel';
 import Twitter from '@widgets/twitter';
 import Numbers from '@widgets/numbers';
 import Weather from '@widgets/weather';
+import LiveStream from '@widgets/livestream';
 
 const SWITCH_INTERVAL = 20000;
 
@@ -28,6 +29,11 @@ const widgets = [
   {
     panel: <Numbers.Panel />,
     text: 'MojoTech by the Numbers',
+    showWeather: true,
+  },
+  {
+    panel: <LiveStream.Panel />,
+    text: 'Boulder',
     showWeather: true,
   },
 ];

--- a/app/javascript/components/widgets/livestream/index.jsx
+++ b/app/javascript/components/widgets/livestream/index.jsx
@@ -1,0 +1,5 @@
+import Panel from '@widgets/livestream/panel';
+
+export default {
+  Panel,
+};

--- a/app/javascript/components/widgets/livestream/panel.jsx
+++ b/app/javascript/components/widgets/livestream/panel.jsx
@@ -1,6 +1,16 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Query } from 'react-apollo';
+import gql from 'graphql-tag';
+import { LoadingMessage, DisconnectedMessage } from '@messages/message';
 
+const getLivestreamUrl = gql`
+  {
+    primaryLocation {
+      livestreamUrl
+    }
+  }
+`;
 const Wrapper = styled.div`
   position: fixed;
   top: 0px;
@@ -8,19 +18,32 @@ const Wrapper = styled.div`
   overflow: hidden;
 `;
 
-const LiveStream = () => {
-  return (
-    <Wrapper>
-      <iframe
-        title="livestream"
-        width={window.innerWidth}
-        height={window.innerHeight}
-        src=""
-        frameBorder="0"
-        allow="autoplay; encrypted-media; picture-in-picture"
-      />
-    </Wrapper>
-  );
-};
+const LiveStream = () => (
+  <Query query={getLivestreamUrl}>
+    {({ loading, error, data }) => {
+      if (loading) {
+        return <LoadingMessage />;
+      }
+
+      if (error) {
+        return <DisconnectedMessage />;
+      }
+
+      const { livestreamUrl } = data.primaryLocation;
+      return (
+        <Wrapper>
+          <iframe
+            title="livestream"
+            width={window.innerWidth}
+            height={window.innerHeight}
+            src={livestreamUrl}
+            frameBorder="0"
+            allow="autoplay; encrypted-media; picture-in-picture"
+          />
+        </Wrapper>
+      );
+    }}
+  </Query>
+);
 
 export default LiveStream;

--- a/app/javascript/components/widgets/livestream/panel.jsx
+++ b/app/javascript/components/widgets/livestream/panel.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const LiveStream = () => {
+  return <>test</>;
+};
+
+export default LiveStream;

--- a/app/javascript/components/widgets/livestream/panel.jsx
+++ b/app/javascript/components/widgets/livestream/panel.jsx
@@ -1,7 +1,26 @@
 import React from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  overflow: hidden;
+`;
 
 const LiveStream = () => {
-  return <>test</>;
+  return (
+    <Wrapper>
+      <iframe
+        title="livestream"
+        width={window.innerWidth}
+        height={window.innerHeight}
+        src=""
+        frameBorder="0"
+        allow="autoplay; encrypted-media; picture-in-picture"
+      />
+    </Wrapper>
+  );
 };
 
 export default LiveStream;

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -157,6 +157,24 @@
           "description": null,
           "fields": [
             {
+              "name": "livestreamUrl",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "bathroomCode",
               "description": null,
               "args": [

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -37,4 +37,8 @@ class Location < ApplicationRecord
   def bathroom_code
     ENV['BATHROOM_CODE']
   end
+
+  def livestream_url
+    ENV['YOUTUBE_LIVESTREAM_URL']
+  end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -40,6 +40,7 @@ enum EventSource {
 }
 
 type Location {
+  livestreamUrl: String!
   bathroomCode: String!
   cityName: String!
   dayAnnouncements: [Announcement!]!


### PR DESCRIPTION
Here's a start at the Boulder livestream.

The idea here is that each office would have their own unlisted livestream of their respective office, and the other would view it. From my understanding, Youtube livestreams can operate 24/7, so this could be left on if desired.

The livestream url is set in the env file and should ideally follow this pattern:
https://www.youtube.com/embed/live_stream?channel=[channel_id]&autoplay=1&mute=1&loop=1

This should create a permanent youtube livestream link that is associated with the channel, and not that specific livestream. This would still connect if the livestream was taken down and put back up later.

I'm also not sure if we even want to do this, as I have no idea if people are okay with being livestreamed in the first place.