### PR TITLE
Traffic Alerts

### DIFF
--- a/app/graphql/types/location_type.rb
+++ b/app/graphql/types/location_type.rb
@@ -12,4 +12,5 @@ class Types::LocationType < Types::BaseObject
   field "wifi_name", String
   field "wifi_password", String
   field "bathroom_code", String
+  field "traffic_cams", [Types::TrafficCamType]
 end

--- a/app/graphql/types/traffic_cam_type.rb
+++ b/app/graphql/types/traffic_cam_type.rb
@@ -1,0 +1,7 @@
+class Types::TrafficCamType < Types::BaseObject
+  graphql_name "TrafficCam"
+
+  field "id", ID
+  field "title", String
+  field "url", String
+end

--- a/app/javascript/components/widget-controller.jsx
+++ b/app/javascript/components/widget-controller.jsx
@@ -35,6 +35,9 @@ const widgets = [
     panel: <Traffic.Panel />,
     text: 'Traffic',
     showWeather: true,
+    hourStart: 16,
+    hourStop: 23,
+    isVisible: false,
   },
 ];
 
@@ -71,19 +74,35 @@ export class WidgetController extends React.Component {
 
   moveDown = () => {
     this.setState(({ index }) => ({
-      index: (index + 1) % widgets.length,
+      index: (index + 1) % this.getVisibleWidgets().length,
     }));
   };
 
   moveUp = () => {
     this.setState(({ index }) => ({
-      index: mathMod(index - 1, widgets.length),
+      index: mathMod(index - 1, this.getVisibleWidgets().length),
     }));
+  };
+
+  getVisibleWidgets = () => {
+    const date = new Date();
+    const currentHour = date.getHours();
+
+    return widgets.filter(widget => {
+      if (widget.hourStart !== undefined) {
+        if (currentHour >= widget.hourStart && currentHour < widget.hourStop) {
+          return true;
+        }
+        return false;
+      }
+      return true;
+    });
   };
 
   render() {
     const { index } = this.state;
-    const currentWidget = widgets[index];
+    const visibleWidgets = this.getVisibleWidgets();
+    const currentWidget = visibleWidgets[index];
 
     return (
       // eslint-disable-next-line
@@ -95,7 +114,7 @@ export class WidgetController extends React.Component {
       >
         <FullPanel currentWidget={currentWidget.panel} />
         <SidePanel
-          widgets={widgets}
+          widgets={visibleWidgets}
           selectedWidget={index}
           totalTime={SWITCH_INTERVAL}
           tabDown={this.moveDown}

--- a/app/javascript/components/widget-controller.jsx
+++ b/app/javascript/components/widget-controller.jsx
@@ -6,6 +6,7 @@ import SidePanel from '@components/side-panel';
 import Twitter from '@widgets/twitter';
 import Numbers from '@widgets/numbers';
 import Weather from '@widgets/weather';
+import Traffic from '@widgets/traffic';
 
 const SWITCH_INTERVAL = 20000;
 
@@ -28,6 +29,11 @@ const widgets = [
   {
     panel: <Numbers.Panel />,
     text: 'MojoTech by the Numbers',
+    showWeather: true,
+  },
+  {
+    panel: <Traffic.Panel />,
+    text: 'Traffic',
     showWeather: true,
   },
 ];

--- a/app/javascript/components/widgets/traffic/index.jsx
+++ b/app/javascript/components/widgets/traffic/index.jsx
@@ -1,0 +1,5 @@
+import Panel from '@widgets/traffic/panel';
+
+export default {
+  Panel,
+};

--- a/app/javascript/components/widgets/traffic/panel.jsx
+++ b/app/javascript/components/widgets/traffic/panel.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import styled from 'styled-components';
+import { colors, weights, fonts, fontSizes } from '@lib/theme';
+import { GreySubText } from '@components/typography';
+
+const Title = styled.div`
+  margin-top: 16px;
+  margin-bottom: 8px;
+  color: ${colors.white};
+  weight: ${weights.regular};
+  font-size: 24px;
+  font-family: ${fonts.extended};
+`;
+
+const TrafficCam = styled.img`
+  width: 400px;
+  height: 250px;
+`;
+
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  text-align: center;
+  margin-right: 50px;
+`;
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding-right: 700px;
+`;
+
+const Notice = styled(GreySubText)`
+  margin-top: 16px;
+  font-size: ${fontSizes.tiny};
+  text-align: center;
+  margin-right: 750px;
+`;
+
+const Traffic = () => (
+  <>
+    <Row>
+      <Column>
+        <Title>I-95 at Broad St</Title>
+        <TrafficCam src="http://www.dot.ri.gov/img/travel/camimages/95-21%20I-95%20S%20@%20Broad%20St%20.jpg" />
+        <Title>I-95 at Lonsdale</Title>
+        <TrafficCam src="http://www.dot.ri.gov/img/travel/camimages/95-26%20I-95%20N%20@%20Lonsdale%20Ave.jpg" />
+        <Title>I-95 at Kinsley</Title>
+        <TrafficCam src="http://www.dot.ri.gov/img/travel/camimages/95-22b%20I-95%20N%20@%20Kinsley%20Ave.jpg" />
+      </Column>
+      <Column>
+        <Title>Exit 10 (near I-295)</Title>
+        <TrafficCam src="http://www.dot.ri.gov/img/travel/camimages/95-11%20I-95%20N%20@%20Toll%20Gate%20Rd.jpg" />
+        <Title>I-95 I-195 Split</Title>
+        <TrafficCam src="http://www.dot.ri.gov/img/travel/camimages/195-1%20I-195%20W%20Split%20@%20I-95.jpg" />
+        <Title>Tobey Street</Title>
+        <TrafficCam src="http://www.dot.ri.gov/img/travel/camimages/6-2%20Rt%206%20E%20%20%2010%20N%20@%20Tobey%20St.jpg" />
+      </Column>
+    </Row>
+    <Notice>Images from http://www.dot.ri.gov</Notice>
+  </>
+);
+
+export default Traffic;

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -309,6 +309,32 @@
               "deprecationReason": null
             },
             {
+              "name": "trafficCams",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "TrafficCam",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "weather",
               "description": null,
               "args": [
@@ -2343,6 +2369,73 @@
           "fields": null,
           "inputFields": null,
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TrafficCam",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
           "enumValues": null,
           "possibleTypes": null
         },

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -6,6 +6,7 @@ class Location < ApplicationRecord
 
   has_many :announcements, inverse_of: :location, dependent: :destroy
   has_many :solarcycles, dependent: :destroy
+  has_many :traffic_cams, dependent: :destroy
 
   def self.primary(city_name = ENV['PRIMARY_CITY_NAME'])
     find_by(city_name: city_name)

--- a/app/models/traffic_cam.rb
+++ b/app/models/traffic_cam.rb
@@ -1,0 +1,2 @@
+class TrafficCam < ApplicationRecord
+end

--- a/db/migrate/20190823182602_create_traffic_cams.rb
+++ b/db/migrate/20190823182602_create_traffic_cams.rb
@@ -1,0 +1,10 @@
+class CreateTrafficCams < ActiveRecord::Migration[5.2]
+  def change
+    create_table :traffic_cams do |t|
+      t.string :title, null: false
+      t.string :url, null: false
+      t.references :location
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_04_172236) do
+ActiveRecord::Schema.define(version: 2019_08_23_182602) do
 
   create_table "announcements", force: :cascade do |t|
     t.datetime "publish_on", null: false
@@ -56,6 +56,15 @@ ActiveRecord::Schema.define(version: 2019_06_04_172236) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["location_id"], name: "index_solarcycles_on_location_id"
+  end
+
+  create_table "traffic_cams", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "url", null: false
+    t.integer "location_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_traffic_cams_on_location_id"
   end
 
   create_table "widgets", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
-Location.create(
+providence = Location.create(
   latitude: 41.823989,
   longitude: -71.412834,
   city_name: 'Providence',
@@ -52,4 +52,40 @@ Widget.create(
   enabled: true,
   duration_seconds: 20,
   position: 3
+)
+
+TrafficCam.create(
+  title: "I-95 at Broad St",
+  url: "http://www.dot.ri.gov/img/travel/camimages/95-21%20I-95%20S%20@%20Broad%20St%20.jpg",
+  location_id: providence.id
+)
+
+TrafficCam.create(
+  title: "I-95 at Lonsdale",
+  url: "http://www.dot.ri.gov/img/travel/camimages/95-26%20I-95%20N%20@%20Lonsdale%20Ave.jpg",
+  location_id: providence.id
+)
+
+TrafficCam.create(
+  title: "I-95 at Kinsley",
+  url: "http://www.dot.ri.gov/img/travel/camimages/95-22b%20I-95%20N%20@%20Kinsley%20Ave.jpg",
+  location_id: providence.id
+)
+
+TrafficCam.create(
+  title: "Exit 10 (near I-295)",
+  url: "http://www.dot.ri.gov/img/travel/camimages/95-11%20I-95%20N%20@%20Toll%20Gate%20Rd.jpg",
+  location_id: providence.id
+)
+
+TrafficCam.create(
+  title: "I-95 I-195 Split",
+  url: "http://www.dot.ri.gov/img/travel/camimages/195-1%20I-195%20W%20Split%20@%20I-95.jpg",
+  location_id: providence.id
+)
+
+TrafficCam.create(
+  title: "Tobey Street",
+  url: "http://www.dot.ri.gov/img/travel/camimages/6-2%20Rt%206%20E%20%20%2010%20N%20@%20Tobey%20St.jpg",
+  location_id: providence.id
 )

--- a/schema.graphql
+++ b/schema.graphql
@@ -48,6 +48,7 @@ type Location {
   latitude: Float!
   longitude: Float!
   timezone: String!
+  trafficCams: [TrafficCam!]!
   weather: Weather!
   wifiName: String!
   wifiPassword: String!
@@ -94,6 +95,12 @@ type Subscription {
 
   # Latest weather data retrieved
   weatherPublished(latitude: Float!, longitude: Float!): Weather!
+}
+
+type TrafficCam {
+  id: ID!
+  title: String!
+  url: String!
 }
 
 type TweetInteraction {

--- a/spec/models/traffic_cam_spec.rb
+++ b/spec/models/traffic_cam_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TrafficCam, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
There was some desire to see the state of traffic when leaving for the day, so this should help notify people where the heaviest traffic is around Providence. 

This panel only appears after 4pm every day, and will disable itself at 11pm, so it only appears during times it would be helpful. 

The images refresh when the panel is loaded, so they are reasonably up to date for viewing.

![Screen Shot 2019-08-15 at 2 09 06 PM](https://user-images.githubusercontent.com/48894331/63117164-34cf8f80-bf69-11e9-81e9-981aa3706d6e.png)

