### PR TITLE
fix: switch local state to filtered world prop

### DIFF
--- a/app/javascript/components/widgets/numbers/ducks.jsx
+++ b/app/javascript/components/widgets/numbers/ducks.jsx
@@ -2,22 +2,18 @@
 import React from 'react';
 import { withQuery } from 'react-apollo';
 import gql from 'graphql-tag';
-import { inflateSync, deflateSync } from 'zlib';
 
 export const withLocalMutation = WrappedComponent => props => (
   <WrappedComponent
     {...{
       ...props,
-      mutation: variables => {
+      mutation: ({ world }) => {
         // eslint-disable-next-line react/prop-types
         props.client.writeData({
           data: {
             fallingBlocksState: {
               __typename: 'FallingBlocksState',
-              ...variables,
-              world: deflateSync(Buffer.from(variables.world)).toString(
-                'base64',
-              ),
+              world,
             },
           },
         });
@@ -27,51 +23,29 @@ export const withLocalMutation = WrappedComponent => props => (
 );
 
 export const nullState = {
-  githubPull: 0,
-  githubCommit: 0,
-  slackMessage: 0,
   world: null,
 };
 
 export const getState = ({
-  fallingBlocksState: {
-    githubCommit = 0,
-    githubPull = 0,
-    slackMessage = 0,
-    world = null,
-  } = {},
+  fallingBlocksState: { world = null } = {},
 } = {}) => {
-  if (!world) {
+  if (!Array.isArray(world)) {
     return nullState;
   }
 
-  try {
-    return {
-      githubCommit,
-      githubPull,
-      slackMessage,
-      world: inflateSync(Buffer.from(world, 'base64')).toString(),
-    };
-  } catch (ex) {
-    // eslint-disable-next-line no-console
-    console.warn(`Failed to inflate world: ${ex}`);
-    return nullState;
-  }
+  return { world };
 };
 
 export const withLocalState = withQuery(
   gql`
     {
       fallingBlocksState @client {
-        githubCommit
-        githubPull
-        slackMessage
         world
       }
     }
   `,
   {
-    props: ({ data }) => ({ localState: getState(data) }),
+    props: ({ data }) => getState(data),
     options: {
       fetchPolicy: 'cache-first',
     },

--- a/app/javascript/components/widgets/numbers/falling-blocks.jsx
+++ b/app/javascript/components/widgets/numbers/falling-blocks.jsx
@@ -80,8 +80,6 @@ class Scene extends React.Component {
     super(props);
     const { world, ...currentState } = this.getLocalState(props);
     this.state = {
-      height: window.innerHeight,
-      width: window.innerWidth,
       ...currentState,
     };
     this.scene = React.createRef();
@@ -147,12 +145,15 @@ class Scene extends React.Component {
       enableSleeping: true,
     });
 
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
     this.renderMatter = Render.create({
       element: this.scene.current,
       engine: this.engine,
       options: {
-        width: window.innerWidth,
-        height: window.innerHeight,
+        width,
+        height,
         background: 'transparent',
         wireframes: false,
         showSleeping: false,
@@ -166,35 +167,23 @@ class Scene extends React.Component {
        * and expand in height/width evenly around that point
        */
 
-      Bodies.rectangle(
-        this.state.width / 2,
-        this.state.height - wallWidth / 2,
-        this.state.width,
-        wallWidth,
-        {
-          isStatic: true,
-          render: {
-            fillStyle: 'black',
-          },
+      Bodies.rectangle(width / 2, height - wallWidth / 2, width, wallWidth, {
+        isStatic: true,
+        render: {
+          fillStyle: 'black',
         },
-      ),
-      Bodies.rectangle(
-        wallWidth / 2,
-        this.state.height / 2,
-        wallWidth,
-        this.state.height + padding,
-        {
-          isStatic: true,
-          render: {
-            fillStyle: 'black',
-          },
+      }),
+      Bodies.rectangle(wallWidth / 2, height / 2, wallWidth, height + padding, {
+        isStatic: true,
+        render: {
+          fillStyle: 'black',
         },
-      ),
+      }),
       Bodies.rectangle(
-        this.state.width - wallWidth / 2 - sidePanelWidth,
-        this.state.height / 2,
+        width - wallWidth / 2 - sidePanelWidth,
+        height / 2,
         wallWidth,
-        this.state.height + padding,
+        height + padding,
         {
           isStatic: true,
           render: {

--- a/app/javascript/components/widgets/numbers/falling-blocks.jsx
+++ b/app/javascript/components/widgets/numbers/falling-blocks.jsx
@@ -11,8 +11,7 @@ import {
   Runner,
 } from 'matter-js';
 import { graphql, withApollo } from 'react-apollo';
-import { pathOr, keys, compose } from 'ramda';
-import Resurrect from 'resurrect-js';
+import { countBy, pathOr, keys, compose } from 'ramda';
 import PropTypes from 'prop-types';
 import { getEventCounts } from '@numbers/queries';
 import githubPullIcon from '@images/pr.png';
@@ -21,12 +20,78 @@ import slackMessageIcon from '@images/slack.png';
 import { getStartOfWeek } from '@lib/datetime';
 import { withLocalMutation, withLocalState } from '@numbers/ducks';
 import { sidePanelWidth } from '@lib/theme';
+import { isPresent } from '@lib/util';
 
 const blockTypes = {
   githubPull: githubPullIcon,
   githubCommit: githubCommitIcon,
   slackMessage: slackMessageIcon,
 };
+
+const blockTypeKeyFromValue = value =>
+  keys(blockTypes).find(key => blockTypes[key] === value);
+
+const createFallingBlock = (x, y, blockType, options = {}) =>
+  Bodies.polygon(x, y, 8, 8, {
+    restitution: 0.25,
+    friction: 0.8,
+    render: {
+      sprite: {
+        texture: blockTypes[blockType],
+      },
+    },
+    ...options,
+  });
+
+const countByBlockType = countBy(body => body[0]);
+
+const serializeFallingBlock = ({
+  angle,
+  angularSpeed,
+  angularVelocity,
+  isSleeping,
+  isStatic,
+  position,
+  render,
+  sleepCounter,
+  visible,
+  velocity,
+}) => [
+  blockTypeKeyFromValue(render.sprite.texture),
+  angle,
+  angularSpeed,
+  angularVelocity,
+  isSleeping,
+  isStatic,
+  position,
+  sleepCounter,
+  visible,
+  velocity,
+];
+
+const deserializeFallingBlock = ([
+  blockType,
+  angle,
+  angularSpeed,
+  angularVelocity,
+  isSleeping,
+  isStatic,
+  position,
+  sleepCounter,
+  visible,
+  velocity,
+]) =>
+  createFallingBlock(position.x, position.y, blockType, {
+    angle,
+    angularSpeed,
+    angularVelocity,
+    isSleeping,
+    isStatic,
+    sleepCounter,
+    visible,
+    velocity,
+  });
+
 const wallWidth = 50;
 // Padding applied to the height of the walls to prevent blocks created contemporaneously from colliding.
 const padding = 50;
@@ -69,45 +134,35 @@ const getImageFromCache = imagePath => {
 class Scene extends React.Component {
   static propTypes = {
     mutation: PropTypes.func.isRequired,
+    world: PropTypes.arrayOf(PropTypes.array),
     data: PropTypes.shape({
       loading: PropTypes.bool.isRequired,
     }).isRequired,
+  };
+
+  static defaultProps = {
+    world: null,
   };
 
   imageCache = {};
 
   constructor(props) {
     super(props);
-    const { world, ...currentState } = this.getLocalState(props);
     this.state = {
-      ...currentState,
+      githubPull: 0,
+      githubCommit: 0,
+      slackMessage: 0,
     };
     this.scene = React.createRef();
     this.overlay = React.createRef();
     this.timer = null;
-    this.res = new Resurrect({ prefix: '$', cleanup: true });
   }
 
   componentDidMount() {
+    const { world } = this.props;
     this.setupWorld();
-    const { world } = this.getLocalState(this.props);
-    if (world) {
-      const loadedWorld = this.res.resurrect(world);
-      const counts = this.getCountsFromProps(this.props);
-      const {
-        data: { loading },
-      } = this.props;
-
-      if (
-        loading ||
-        (this.state.githubCommit <= counts.githubCommit &&
-          this.state.githubPull <= counts.githubPull &&
-          this.state.slackMessage <= counts.slackMessage)
-      ) {
-        Engine.merge(this.engine, { world: loadedWorld });
-      } else {
-        this.setState({ githubCommit: 0, githubPull: 0, slackMessage: 0 });
-      }
+    if (isPresent(world)) {
+      this.restoreWorld(world);
     }
     Composite.allBodies(this.engine.world)
       .filter(body => !body.isStatic)
@@ -117,17 +172,8 @@ class Scene extends React.Component {
   }
 
   componentWillUnmount() {
-    const allBodies = Composite.allBodies(this.engine.world);
-    allBodies
-      .filter(body => body.isOnOverlay)
-      .forEach(body => {
-        // eslint-disable-next-line no-param-reassign
-        body.isOnOverlay = false;
-        return body.isOnOverlay;
-      });
-
     clearTimeout(this.timer);
-    this.save();
+    this.saveWorld();
     this.teardownWorld();
   }
 
@@ -198,19 +244,47 @@ class Scene extends React.Component {
     Render.run(this.renderMatter);
   }
 
-  getInitialCounts = () => ({
-    githubPull: 0,
-    githubCommit: 0,
-    slackMessage: 0,
-  });
+  getCountsFromProps = pathOr(
+    {
+      githubPull: 0,
+      githubCommit: 0,
+      slackMessage: 0,
+    },
+    ['data', 'events', 'count'],
+  );
 
-  getLocalState = pathOr(this.getInitialCounts(), ['localState']);
+  restoreWorld = world => {
+    const worldCounts = countByBlockType(world);
+    const counts = this.getCountsFromProps(this.props);
+    const {
+      data: { loading },
+    } = this.props;
 
-  getCountsFromProps = pathOr(this.getInitialCounts(), [
-    'data',
-    'events',
-    'count',
-  ]);
+    if (loading) {
+      return;
+    }
+
+    if (
+      worldCounts.githubCommit <= counts.githubCommit &&
+      worldCounts.githubPull <= counts.githubPull &&
+      worldCounts.slackMessage <= counts.slackMessage
+    ) {
+      World.add(this.engine.world, world.map(deserializeFallingBlock));
+      this.setState(worldCounts);
+    } else {
+      this.setState({ githubCommit: 0, githubPull: 0, slackMessage: 0 });
+    }
+  };
+
+  saveWorld = () => {
+    const world = Composite.allBodies(this.engine.world)
+      .filter(({ render }) =>
+        blockTypeKeyFromValue(pathOr(false, ['sprite', 'texture'], render)),
+      )
+      .map(serializeFallingBlock);
+
+    this.props.mutation({ world });
+  };
 
   teardownWorld = () => {
     Render.stop(this.renderMatter);
@@ -239,23 +313,25 @@ class Scene extends React.Component {
   };
 
   addBlocks = () => {
+    const {
+      data: { loading },
+    } = this.props;
+
+    if (loading) {
+      this.timer = setTimeout(this.addBlocks, 200);
+      return;
+    }
+
     const block = this.nextBlock();
-    const widthBetweenWalls = this.state.width - wallWidth - sidePanelWidth;
+    const width = window.innerWidth;
+    const widthBetweenWalls = width - wallWidth - sidePanelWidth;
     const randomDist =
       (widthBetweenWalls * (Math.random() + Math.random())) / 2;
     // add circles to the world,
     // randomly pick a point from one wall edge to the other
     // so that they don't fall directly on top of each other.
     if (block) {
-      const newBlock = Bodies.polygon(randomDist, -10, 8, 8, {
-        restitution: 0.25,
-        friction: 0.8,
-        render: {
-          sprite: {
-            texture: blockTypes[block],
-          },
-        },
-      });
+      const newBlock = createFallingBlock(randomDist, -10, block);
 
       this.setState(state => ({ [block]: state[block] + 1 }));
 
@@ -297,34 +373,6 @@ class Scene extends React.Component {
     allBodies
       .filter(body => body.isStatic)
       .forEach(body => this.addToOverlay(body));
-  }
-
-  save() {
-    const { githubPull, githubCommit, slackMessage } = this.state;
-    this.props.mutation({
-      githubPull,
-      githubCommit,
-      slackMessage,
-      world: this.serialise(this.engine.world),
-    });
-  }
-
-  serialise(object) {
-    return this.res.stringify(object, (key, value) => {
-      // serialise fails if it attempts to work on an event, so we need to avoid them
-      if (key === 'events') {
-        return null;
-      }
-      // limit precision of floats
-      if (!/^#/.exec(key) && typeof value === 'number') {
-        const fixed = parseFloat(value.toFixed(3));
-
-        if (fixed === 0 && value !== 0) return value;
-
-        return fixed;
-      }
-      return value;
-    });
   }
 
   render() {

--- a/app/javascript/components/widgets/numbers/falling-blocks.jsx
+++ b/app/javascript/components/widgets/numbers/falling-blocks.jsx
@@ -171,6 +171,16 @@ class Scene extends React.Component {
     this.addBlocks();
   }
 
+  componentDidUpdate(prevProps) {
+    const {
+      world,
+      data: { loading },
+    } = this.props;
+    if (prevProps.data.loading && !loading && isPresent(world)) {
+      this.restoreWorld(world);
+    }
+  }
+
   componentWillUnmount() {
     clearTimeout(this.timer);
     this.saveWorld();
@@ -265,9 +275,9 @@ class Scene extends React.Component {
     }
 
     if (
-      worldCounts.githubCommit <= counts.githubCommit &&
-      worldCounts.githubPull <= counts.githubPull &&
-      worldCounts.slackMessage <= counts.slackMessage
+      (worldCounts.githubCommit || 0) <= counts.githubCommit &&
+      (worldCounts.githubPull || 0) <= counts.githubPull &&
+      (worldCounts.slackMessage || 0) <= counts.slackMessage
     ) {
       World.add(this.engine.world, world.map(deserializeFallingBlock));
       this.setState(worldCounts);

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "react-highlight-words": "^0.16.0",
     "resurrect-js": "^1.0.1",
     "styled-components": "^3.2.6",
-    "styled-normalize": "^4.0.0",
-    "zlib": "^1.0.5"
+    "styled-normalize": "^4.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10039,8 +10039,3 @@ zen-observable@^0.8.0:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.14.tgz#d33058359d335bc0db1f0af66158b32872af3bf7"
   integrity sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g==
-
-zlib@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/zlib/-/zlib-1.0.5.tgz#6e7c972fc371c645a6afb03ab14769def114fcc0"
-  integrity sha1-bnyXL8NxxkWmr7A6sUdp3vEU/MA=


### PR DESCRIPTION
The matterjs world was being serialized as a large javascript object and
compressed with zlib. This switches that serialization to a filtered
array of javascript object properties. The local state of counts is then
inferred from the world when the graphql query is done loading.