### PR TITLE
fix: Typo in Weather Client, read ENV for WEATHER_API_KEY

### DIFF
--- a/app/lib/clients/weather_client.rb
+++ b/app/lib/clients/weather_client.rb
@@ -33,7 +33,7 @@ class Clients::WeatherClient
   end
 
   def self.get(latitude, longitude)
-    response = Faraday.get(WEATHER_API_URL % { lat: latitude, lon: longitude, key: ENV['WEATHER_API'] })
+    response = Faraday.get(WEATHER_API_URL % { lat: latitude, lon: longitude, key: ENV['WEATHER_API_KEY'] })
     return JSON.parse(response.body) if response.success?
   end
 end


### PR DESCRIPTION
`weather_client.rb` was previously reading for `WEATHER_API`, rather than the instructed `WEATHER_API_KEY`