### PR TITLE
Ac/weather effects

### DIFF
--- a/app/javascript/components/get-weather-query.jsx
+++ b/app/javascript/components/get-weather-query.jsx
@@ -48,6 +48,7 @@ export const WeatherQuery = ({
         return <LoadingMessage />;
       }
       if (error) {
+        console.error(error); // eslint-disable-line
         return <DisconnectedMessage />;
       }
       return (

--- a/app/javascript/components/hocs/with-fragment.jsx
+++ b/app/javascript/components/hocs/with-fragment.jsx
@@ -7,7 +7,7 @@ import hoistNonReactStatic from 'hoist-non-react-statics';
  * WrappedComponent's fragment names
  */
 export default function withFragment(WrappedComponent) {
-  const Enhanced = props => {
+  const Enhanced = React.memo(props => {
     const fragmentKeys = Object.keys(WrappedComponent.fragments);
     const fragmentDataProps = fragmentKeys.reduce((accProps, fragmentKey) => {
       const fragment = WrappedComponent.fragments[fragmentKey];
@@ -18,7 +18,7 @@ export default function withFragment(WrappedComponent) {
     }, {});
 
     return <WrappedComponent {...props} {...fragmentDataProps} />;
-  };
+  });
 
   // retain fragments defined statically on WrappedComponent
   hoistNonReactStatic(Enhanced, WrappedComponent);

--- a/app/javascript/components/widgets/weather/panel.jsx
+++ b/app/javascript/components/widgets/weather/panel.jsx
@@ -75,6 +75,10 @@ class SubscribedWeather extends React.Component {
     this.props.subscribeToPublishedEvents();
   }
 
+  shouldComponentUpdate(nextProps) {
+    return this.props.primaryLocation !== nextProps.primaryLocation;
+  }
+
   render() {
     const { primaryLocation } = this.props;
     const { weather } = primaryLocation;

--- a/app/javascript/components/widgets/weather/sunrise-sunset.jsx
+++ b/app/javascript/components/widgets/weather/sunrise-sunset.jsx
@@ -14,6 +14,7 @@ import { parseTime, timeDiffInMinutes } from '@lib/datetime';
 import { WhiteText } from '@components/typography';
 import withFragment from '@hocs/with-fragment';
 import SemiCircle from '@weather/semi-circle';
+import WeatherEffect from '@weather/weather-effect';
 
 const containerHeight = '344px';
 
@@ -53,7 +54,10 @@ const SunsetLabel = styled.div`
 const getSunriseSunsetWeather = gql`
   fragment SunriseSunsetWeather on Weather {
     moonPhase
+    ...WeatherEffect
   }
+
+  ${WeatherEffect.fragments.weather}
 `;
 
 const getSunriseSunsetLocation = gql`
@@ -85,6 +89,7 @@ const SunriseSunset = ({ location, weather }) => {
 
   return (
     <SunriseSunsetContainer>
+      <WeatherEffect weather={weather} />
       <SemiCircle
         totalTime={timeDiffInMinutes(
           new Date(endTime.time),

--- a/app/javascript/components/widgets/weather/weather-effect.jsx
+++ b/app/javascript/components/widgets/weather/weather-effect.jsx
@@ -1,0 +1,335 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { css, keyframes } from 'styled-components';
+import gql from 'graphql-tag';
+import withFragment from '@hocs/with-fragment';
+
+const getWeatherEffect = gql`
+  fragment WeatherEffect on Weather {
+    current {
+      weather {
+        id
+      }
+    }
+  }
+`;
+
+const EffectContainer = styled.div`
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  mask-image: radial-gradient(farthest-side at bottom, #000e, #000b 70%, #0000);
+`;
+
+const Drop = styled.div`
+  position: absolute;
+  bottom: 100%;
+  pointer-events: none;
+`;
+
+const floorTo = (value, decimal) => {
+  const exp = 10 ** decimal;
+  return Math.floor(value * exp) / exp;
+};
+
+const percent = value => value * 100;
+
+const evenlyDistribute = (index, total) => {
+  return floorTo(percent(index + Math.random() * 0.8) / total, 2);
+};
+
+const WeatherWrapper = React.memo(({ Type, duration, variance, count }) =>
+  new Array(count).fill().map((_, index) => (
+    <Type
+      key={index.toString()}
+      style={{
+        left: `${evenlyDistribute(index, count)}%`,
+        animationDelay: `${Math.random() * -(duration + variance)}s`,
+        animationDuration: `${duration + Math.random() * variance}s`,
+        animationIterationCount: 'infinite',
+      }}
+    />
+  )),
+);
+
+WeatherWrapper.propTypes = {
+  Type: PropTypes.object.isRequired, // eslint-disable-line
+  duration: PropTypes.number.isRequired,
+  variance: PropTypes.number.isRequired,
+  count: PropTypes.number.isRequired,
+};
+
+/* Weather ID Types: https://openweathermap.org/weather-conditions#Weather-Condition-Codes-2
+ * 8__: Clear / Clouds
+ * 7__: Atmosphere (particles)
+ * 6__: Snow
+ * 5__: Rain
+ * 3__: Drizzle
+ * 2__: Thunder
+ *     _0_: w/ Rain
+ *     _1_: Clear
+ *     _2_: Ragged, clearing?
+ *     _3_: w/ Drizzle
+ */
+
+// #region Rain
+
+const RainDropFrames = keyframes`
+  0% {
+    bottom: 100%;
+  }
+  100% {
+    bottom: -60px;
+  }
+`;
+
+const RainDrop = styled(Drop)`
+  width: 1px;
+  height: 60px;
+  background: linear-gradient(to bottom, #fff0, #ffff);
+  animation: ${RainDropFrames} linear;
+`;
+
+const RainContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  ${props => css`
+    right: ${Math.tan(props.angle / 57.29) * 10}%;
+    transform: skew(${props.angle}deg);
+  `}
+`;
+
+const Rain = ({ duration, variance, count, angle }) => (
+  <RainContainer angle={angle}>
+    <WeatherWrapper {...{ Type: RainDrop, duration, variance, count }} />
+  </RainContainer>
+);
+
+Rain.propTypes = {
+  duration: PropTypes.number.isRequired,
+  variance: PropTypes.number.isRequired,
+  count: PropTypes.number.isRequired,
+  angle: PropTypes.number,
+};
+
+Rain.defaultProps = { angle: 0 };
+
+// #endregion
+// #region Drizzle
+
+const DrizzleDrop = styled(RainDrop)`
+  height: 30px;
+  background: linear-gradient(to bottom, #fff0, #fff8);
+`;
+
+const Drizzle = ({ duration, variance, count }) => (
+  <WeatherWrapper {...{ Type: DrizzleDrop, duration, variance, count }} />
+);
+
+Drizzle.propTypes = {
+  duration: PropTypes.number.isRequired,
+  variance: PropTypes.number.isRequired,
+  count: PropTypes.number.isRequired,
+};
+
+// #endregion
+// #region Snow
+
+const SnowWaveFrames = keyframes`
+  0% {
+    transform: translateX(0px);
+  }
+  30% {
+    transform: translateX(-16px);
+  }
+  70% {
+    transform: translateX(16px);
+  }
+  100% {
+    transform: translateX(0px);
+  }
+`;
+
+const SnowDropFrames = keyframes`
+  0% {
+    bottom: 100%
+  }
+  100% {
+    bottom: -12px;
+  }
+`;
+
+const HeavySnowFallFrames = keyframes`
+  0% {
+    transform: translateX(-80px);
+  }
+  100% {
+    transform: translateX(20px);
+  }
+`;
+
+const HeavySnowFall = styled(Drop)`
+  background: white;
+  width: 4px;
+  height: 4px;
+  border-radius: 4px;
+  animation: ${SnowDropFrames} linear, ${HeavySnowFallFrames} ease-in-out;
+`;
+
+const SnowFall = styled(Drop)`
+  background: white;
+  width: 3px;
+  height: 3px;
+  border-radius: 3px;
+  animation: ${SnowDropFrames} linear, ${SnowWaveFrames} ease-in-out;
+`;
+
+const Snow = ({ duration, variance, count }) => (
+  <WeatherWrapper {...{ Type: SnowFall, duration, variance, count }} />
+);
+
+Snow.propTypes = {
+  duration: PropTypes.number.isRequired,
+  variance: PropTypes.number.isRequired,
+  count: PropTypes.number.isRequired,
+};
+
+const HeavySnow = ({ duration, variance, count }) => (
+  <WeatherWrapper {...{ Type: HeavySnowFall, duration, variance, count }} />
+);
+
+HeavySnow.propTypes = {
+  duration: PropTypes.number.isRequired,
+  variance: PropTypes.number.isRequired,
+  count: PropTypes.number.isRequired,
+};
+
+// #endregion
+// #region Thunder
+
+// Reference: https://codepen.io/Chrislion_me/pen/rVqwbO
+const LightningKeyframes = keyframes`
+{
+  0% {opacity: 0;}
+
+  40% {opacity: 0%;}
+  41% {opacity: 50%;}
+  43% {opacity: 20%;}
+  44% {opacity: 90%;}
+  50% {opacity: 0%;}
+
+  100% {opacity: 0%;}
+}
+`;
+
+const ThunderClouds = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: #dfff;
+  animation: ${LightningKeyframes} ease-out 8s infinite;
+`;
+
+const Clouds = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(to bottom, #999, #9999 40%, #9992 80%, #000b);
+`;
+
+const Thunder = () => {
+  return (
+    <>
+      <Clouds />
+      <ThunderClouds />
+    </>
+  );
+};
+
+// #endregion
+
+/* eslint-disable prettier/prettier */
+const RainLight = () => <Rain duration={0.6} variance={0.4} count={10} />;
+const RainModerate = () => <Rain duration={0.5} variance={0.3} count={20} />;
+const RainHeavy = () => <Rain duration={0.5} variance={0.2} count={35} angle={15} />;
+const RainIntense = () => <Rain duration={0.4} variance={0.1} count={40} angle={30} />;
+const RainExtreme = () => <Rain duration={0.5} variance={0.1} count={60} angle={45} />;
+
+const DrizzleLight = () => <Drizzle duration={1.8} variance={0.5} count={30} />;
+const DrizzleModerate = () => <Drizzle duration={1.5} variance={0.5} count={45} />;
+const DrizzleHeavy = () => <Drizzle duration={1.2} variance={0.4} count={60} />;
+
+const weatherIdMap = {
+  200: <><RainModerate /> <Thunder /></>, // Light rain
+  201: <><RainHeavy /> <Thunder /></>, // Moderate rain
+  202: <><RainIntense /> <Thunder /></>, // Heavy rain
+  210: <Thunder />, // Light thunderstorm
+  211: <Thunder />, // Moderate thunderstorm
+  212: <Thunder />, // Heavy thunderstorm
+  221: <Thunder />, // Ragged thunderstorm
+  230: <><DrizzleLight /> <Thunder /></>, // Light drizzle
+  231: <><DrizzleModerate /> <Thunder /></>, // Moderate drizzle
+  232: <><DrizzleHeavy /> <Thunder /></>, // Heavy drizzle
+  300: <DrizzleLight />, // Light
+  301: <DrizzleModerate />, // Moderate
+  302: <DrizzleHeavy />, // Heavy
+  310: <><DrizzleLight /> <RainLight /></>, // Light rain
+  311: <><DrizzleLight /> <RainModerate /></>, // Moderate rain
+  312: <><DrizzleModerate /> <RainModerate /></>, // Heavy rain
+  313: <><DrizzleLight /> <RainModerate /></>, // Shower rain
+  314: <><DrizzleModerate /> <RainModerate /></>, // Heavy shower rain
+  321: <DrizzleModerate />, // Shower
+  500: <RainLight />, // Light
+  501: <RainModerate />, // Moderate
+  502: <RainHeavy />, // Heavy
+  503: <RainIntense />, // Very heavy
+  504: <RainExtreme />, // Extreme
+  511: <RainModerate />, // Freezing
+  520: <RainLight />, // Light shower
+  521: <RainModerate />, // Moderate shower
+  522: <RainHeavy />, // Heavy shower
+  531: <RainModerate />, // Ragged shower
+  600: <Snow duration={6} variance={2} count={20} />, // Light
+  601: <Snow duration={4} variance={2} count={50} />, // Normal
+  602: <Snow duration={2} variance={2} count={70} />, // Heavy
+  611: <HeavySnow duration={3} variance={2} count={20} />, // Sleet
+  612: <HeavySnow duration={2} variance={1} count={35} />, // Sleet
+  613: <HeavySnow duration={1.5} variance={1} count={45} />, // Sleet
+  615: <><Snow duration={4} variance={2} count={20} /> <RainLight /></>, // Light rain and snow
+  616: <><Snow duration={2} variance={2} count={30} /> <RainModerate /></>, // Rain and snow
+  620: <Snow duration={6} variance={1} count={20} />, // Light
+  621: <Snow duration={4} variance={1} count={50} />, // Normal
+  622: <Snow duration={2} variance={1} count={70} />, // Heavy
+}
+/* eslint-enable prettier/prettier */
+
+const WeatherEffect = ({ weather }) => {
+  const {
+    current: {
+      weather: { id },
+    },
+  } = weather;
+
+  const Effect = weatherIdMap[id];
+
+  return Effect ? <EffectContainer>{Effect}</EffectContainer> : null;
+};
+
+WeatherEffect.propTypes = {
+  weather: PropTypes.shape({
+    current: PropTypes.shape({
+      weather: PropTypes.shape({
+        id: PropTypes.number.isRequired,
+      }).isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+WeatherEffect.fragments = {
+  weather: getWeatherEffect,
+};
+
+export default withFragment(WeatherEffect);

--- a/lib/tasks/simulate.rake
+++ b/lib/tasks/simulate.rake
@@ -25,6 +25,11 @@ namespace :simulate do
     post_slack_event(render_new_slack_announcement_json)
   end
 
+  desc "Simulates a new weather poll"
+  task weather_poll: :environment do
+    WeatherPollerWorker.new.perform
+  end
+
   def disable_github_authentication
     WebHooks::GithubController.skip_before_action :authenticate_github_request!
   end


### PR DESCRIPTION
This adds animated effects to the weather panel, turning it to a globe reflecting current conditions
- Rain, Thunder, Snow, with variations on each
- Hidden debug panel at top right of globe

[![Imgur](https://imgur.com/ERLp8zA.gif)](https://imgur.com/dlJfXDI)

Additional changes: 
- Adds weather poller override: `rake simulate:weather_poll`
- Logs Apollo weather query errors to the console
- Memoizes fragment wrapper, stops unnecessary weather redraw