### PR TITLE
[fix] update docker node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:2.5.7
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash &&\
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash &&\
     apt-get update -qq && apt-get install -yq build-essential nodejs unzip &&\
     gem install bundler -v 1.16 &&\
     npm install -g yarn


### PR DESCRIPTION
This gets the docker builds building at least. 

This is a way simpler setup then running things natively, install docker and run `docker-compose up`. Your web service and all dependent services should load and start with a single command.

The trade off is going to be with developer experience when you start making changes. If you have to rebuild the image every time you make a change its going to slow things down a lot.
