### PR TITLE
feat: add Boulder traffic cams

### DIFF
--- a/app/graphql/types/traffic_cam_type.rb
+++ b/app/graphql/types/traffic_cam_type.rb
@@ -4,4 +4,5 @@ class Types::TrafficCamType < Types::BaseObject
   field "id", ID
   field "title", String
   field "url", String
+  field "feedFormat", String
 end

--- a/app/javascript/components/widgets/traffic/panel.jsx
+++ b/app/javascript/components/widgets/traffic/panel.jsx
@@ -4,6 +4,7 @@ import { splitAt, take } from 'ramda';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 import styled from 'styled-components';
+import ReactHlsPlayer from 'react-hls-player';
 import { colors, weights, fonts, fontSizes } from '@lib/theme';
 import { GreySubText } from '@components/typography';
 import { LoadingMessage, DisconnectedMessage } from '@messages/message';
@@ -15,6 +16,7 @@ const getTrafficCams = gql`
         id
         title
         url
+        feedFormat
       }
     }
   }
@@ -56,16 +58,21 @@ const Notice = styled(GreySubText)`
   margin-right: 750px;
 `;
 
-const TrafficCam = ({ title, url }) => (
+const TrafficCam = ({ title, url, feedFormat }) => (
   <div>
     <Title>{title}</Title>
-    <TrafficCamImage src={url} />
+    {feedFormat === 'video' ? (
+      <ReactHlsPlayer src={url} autoPlay controls width="450px" height="auto" />
+    ) : (
+      <TrafficCamImage src={url} />
+    )}
   </div>
 );
 
 TrafficCam.propTypes = {
   title: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
+  feedFormat: PropTypes.string.isRequired,
 };
 
 const Traffic = () => (
@@ -84,18 +91,19 @@ const Traffic = () => (
         return null;
       }
 
-      const [firstColumn, secondColumn] = splitAt(3, trafficCams);
+      const columnSize = Math.floor(trafficCams.length / 2);
+      const [firstColumn, secondColumn] = splitAt(columnSize, trafficCams);
 
       return (
         <>
           <Row>
             <Column>
-              {take(3, firstColumn).map(({ id, ...cam }) => (
+              {take(columnSize, firstColumn).map(({ id, ...cam }) => (
                 <TrafficCam key={id} {...cam} />
               ))}
             </Column>
             <Column>
-              {take(3, secondColumn).map(({ id, ...cam }) => (
+              {take(columnSize, secondColumn).map(({ id, ...cam }) => (
                 <TrafficCam key={id} {...cam} />
               ))}
             </Column>

--- a/app/javascript/components/widgets/traffic/panel.jsx
+++ b/app/javascript/components/widgets/traffic/panel.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { splitAt, take } from 'ramda';
+import { splitAt, take, uniq, map, compose } from 'ramda';
 import { Query } from 'react-apollo';
 import gql from 'graphql-tag';
 import styled from 'styled-components';
@@ -90,9 +90,12 @@ const Traffic = () => (
       if (!trafficCams) {
         return null;
       }
-
       const columnSize = Math.floor(trafficCams.length / 2);
       const [firstColumn, secondColumn] = splitAt(columnSize, trafficCams);
+      const getUniqUrls = compose(
+        uniq,
+        map(cam => new URL(cam.url).origin),
+      );
 
       return (
         <>
@@ -108,7 +111,10 @@ const Traffic = () => (
               ))}
             </Column>
           </Row>
-          <Notice>Images from http://www.dot.ri.gov</Notice>
+          <Notice>Images from:</Notice>
+          {getUniqUrls(trafficCams).map(url => (
+            <Notice>{url}</Notice>
+          ))}
         </>
       );
     }}

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -2328,6 +2328,24 @@
           "description": null,
           "fields": [
             {
+              "name": "feedFormat",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "args": [

--- a/db/migrate/20210527193617_add_feed_format_to_traffic_cams.rb
+++ b/db/migrate/20210527193617_add_feed_format_to_traffic_cams.rb
@@ -1,0 +1,5 @@
+class AddFeedFormatToTrafficCams < ActiveRecord::Migration[5.2]
+  def change
+    add_column :traffic_cams, :feed_format, :string, null: false, default: 'image'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 2021_05_27_202246) do
     t.integer "location_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "feed_format", default: "image", null: false
     t.index ["location_id"], name: "index_traffic_cams_on_location_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,7 +10,7 @@ providence = Location.find_or_initialize_by(
 end
 providence.save!
 
-Location.find_or_initialize_by(
+boulder = Location.find_or_initialize_by(
   city_name: 'Boulder'
 ) do |r|
   r.latitude = 40.014986
@@ -18,7 +18,8 @@ Location.find_or_initialize_by(
   r.time_zone = 'America/Denver'
   r.wifi_name = 'mojotech-guest'
   r.wifi_password = 'p@ssw0rd'
-end.save!
+end
+boulder.save!
 
 Location.find_or_initialize_by(
   city_name: 'DC'
@@ -153,3 +154,35 @@ end.save!
 TrafficCam.where(
   title: "Tobey Street"
 ).destroy_all
+
+TrafficCam.find_or_initialize_by(
+  title: "Broadway and Canyon"
+) do |r|
+  r.url = "https://videostream.bouldercolorado.gov/live/smil:broadway_and_canyon.smil/playlist.m3u8"
+  r.location = boulder
+  r.feed_format = "video"
+end.save!
+
+TrafficCam.find_or_initialize_by(
+  title: "Foothills and Arapahoe"
+) do |r|
+  r.url = "https://videostream.bouldercolorado.gov/live/smil:foothills_and_arapahoe.smil/playlist.m3u8"
+  r.location = boulder
+  r.feed_format = "video"
+end.save!
+
+TrafficCam.find_or_initialize_by(
+  title: "28th and Colorado"
+) do |r|
+  r.url = "https://videostream.bouldercolorado.gov/live/smil:28th_and_colorado.smil/playlist.m3u8"
+  r.location = boulder
+  r.feed_format = "video"
+end.save!
+
+TrafficCam.find_or_initialize_by(
+  title: "28th and Iris"
+) do |r|
+  r.url = "https://videostream.bouldercolorado.gov/live/smil:28th_and_iris.smil/playlist.m3u8"
+  r.location = boulder
+  r.feed_format = "video"
+end.save!

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -107,6 +107,7 @@ TrafficCam.find_or_initialize_by(
 ) do |r|
   r.url = "http://www.dot.ri.gov/img/travel/camimages/95-21%20I-95%20S%20@%20Broad%20St%20.jpg"
   r.location = providence
+  r.feed_format = "image"
 end.save!
 
 TrafficCam.find_or_initialize_by(
@@ -114,6 +115,7 @@ TrafficCam.find_or_initialize_by(
 ) do |r|
   r.url = "http://www.dot.ri.gov/img/travel/camimages/95-26%20I-95%20N%20@%20Lonsdale%20Ave.jpg"
   r.location = providence
+  r.feed_format = "image"
 end.save!
 
 TrafficCam.find_or_initialize_by(
@@ -121,6 +123,7 @@ TrafficCam.find_or_initialize_by(
 ) do |r|
   r.url = "http://www.dot.ri.gov/img/travel/camimages/95-22b%20I-95%20N%20@%20Kinsley%20Ave.jpg"
   r.location = providence
+  r.feed_format = "image"
 end.save!
 
 TrafficCam.find_or_initialize_by(
@@ -128,6 +131,7 @@ TrafficCam.find_or_initialize_by(
 ) do |r|
   r.url = "http://www.dot.ri.gov/img/travel/camimages/95-11%20I-95%20N%20@%20Toll%20Gate%20Rd.jpg"
   r.location = providence
+  r.feed_format = "image"
 end.save!
 
 TrafficCam.find_or_initialize_by(
@@ -135,6 +139,7 @@ TrafficCam.find_or_initialize_by(
 ) do |r|
   r.url = "http://www.dot.ri.gov/img/travel/camimages/195-1%20I-195%20W%20Split%20@%20I-95.jpg"
   r.location = providence
+  r.feed_format = "image"
 end.save!
 
 TrafficCam.find_or_initialize_by(
@@ -142,6 +147,7 @@ TrafficCam.find_or_initialize_by(
 ) do |r|
   r.url = "https://www.dot.ri.gov/img/travel/camimages/6-1%20Rt%206%20E%20%20%2010%20N%20@%20Dean%20St.jpg"
   r.location = providence
+  r.feed_format = "image"
 end.save!
 
 TrafficCam.where(

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-apollo": "^2.1.4",
     "react-dom": "17.0.2",
     "react-highlight-words": "0.17.0",
+    "react-hls-player": "^3.0.1",
     "regenerator-runtime": "^0.13.7",
     "resurrect-js": "^1.0.1",
     "styled-components": "^4.0.0",

--- a/schema.graphql
+++ b/schema.graphql
@@ -130,6 +130,7 @@ type Subscription {
 }
 
 type TrafficCam {
+  feedFormat: String!
   id: ID!
   title: String!
   url: String!

--- a/yarn.lock
+++ b/yarn.lock
@@ -4729,7 +4729,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-eventemitter3@^4.0.0:
+eventemitter3@^4.0.0, eventemitter3@^4.0.3:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -5667,6 +5667,14 @@ highlight-words-core@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/highlight-words-core/-/highlight-words-core-1.2.2.tgz#1eff6d7d9f0a22f155042a00791237791b1eeaaa"
   integrity sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==
+
+hls.js@^0.14.17:
+  version "0.14.17"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-0.14.17.tgz#0127cff2ec2f994a54eb955fe669ef6153a8e317"
+  integrity sha512-25A7+m6qqp6UVkuzUQ//VVh2EEOPYlOBg32ypr34bcPO7liBMOkKFvbjbCBfiPAOTA/7BSx1Dujft3Th57WyFg==
+  dependencies:
+    eventemitter3 "^4.0.3"
+    url-toolkit "^2.1.6"
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -9731,6 +9739,13 @@ react-highlight-words@0.17.0:
     memoize-one "^4.0.0"
     prop-types "^15.5.8"
 
+react-hls-player@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-hls-player/-/react-hls-player-3.0.1.tgz#0b3844df0c5b3a8316d65e8d557dcb9db8033821"
+  integrity sha512-AeunMCcx4z5x9SnnBrpsHIe3fqKRGRTbzrJIoIHNxSE4JE5bz4RoMsGs6kE/EOQizoNUCZICFwqypK5qOjhoQg==
+  dependencies:
+    hls.js "^0.14.17"
+
 react-is@^16.6.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -11681,6 +11696,11 @@ url-regex-safe@~2.0.2:
     ip-regex "^4.3.0"
     re2 "^1.15.9"
     tlds "^1.217.0"
+
+url-toolkit@^2.1.6:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/url-toolkit/-/url-toolkit-2.2.2.tgz#51ef27b56d3187185f9ecf4a8ac7e8f55203c89d"
+  integrity sha512-l25w6Sy+Iy3/IbogunxhWwljPaDnqpiKvrQRoLBm6DfISco7NyRIS7Zf6+Oxhy1T8kHxWdwLND7ZZba6NjXMug==
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION

![boulder_traffic_cams](https://user-images.githubusercontent.com/84336508/120003935-32a2bd80-bfa4-11eb-822f-8fca90080f37.gif)

Ticket to add support for Boulder Traffic Cams, id : #178271931
Boulder cams are livestreams, not images as with the Providence cams. This PR adds react hls player library to enable displaying these streams. Also adds a field to the database which determines how to display the feed.
Cams are visible after 4pm and can be viewed by setting the env field for CITY_NAME to "Boulder" - as was the case in viewing cams before.