### PR TITLE
feat: Implemented query and comparison of previous/new SHA value

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,12 @@ jobs:
       - run: bundle exec rake db:create
       - run: bundle exec rake db:schema:load
 
+      - run:
+          name: run diff on schema.json
+          command: |
+            bundle exec rake graphql:schema:dump
+            git diff --quiet schema.graphql
+
       # run tests!
       - run:
           name: run tests

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -39,4 +39,12 @@ class Types::QueryType < Types::BaseObject
       Location.primary
     end
   end
+
+  field :schema_sha, String do
+    description "Get current sha"
+  end
+
+  def schema_sha
+    AppEnv['HEROKU_SLUG_COMMIT']
+  end
 end

--- a/app/graphql/types/subscription_type.rb
+++ b/app/graphql/types/subscription_type.rb
@@ -14,4 +14,8 @@ class Types::SubscriptionType < Types::BaseObject
   field :announcement_published, Types::AnnouncementType, description: "An announcement was published"
 
   def announcement_published; end
+
+  field :schema_sha, String, description: "Updated SHA value"
+
+  def schema_sha; end
 end

--- a/app/javascript/components/app.jsx
+++ b/app/javascript/components/app.jsx
@@ -14,6 +14,7 @@ import ActionCableLink from 'graphql-ruby-client/subscriptions/ActionCableLink';
 import { persistCache } from 'apollo-cache-persist';
 import WidgetController from '@components/widget-controller';
 import helioSchema from '@javascript/schema.json';
+import GetVersion from '@components/get-version';
 import GlobalStyle from '../styles';
 
 const cable = ActionCable.createConsumer('/cable');
@@ -76,6 +77,7 @@ const App = () => (
   <ApolloProvider client={client}>
     <GlobalStyle />
     <WidgetController client={client} />
+    <GetVersion />
   </ApolloProvider>
 );
 export default App;

--- a/app/javascript/components/get-version.jsx
+++ b/app/javascript/components/get-version.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Subscription } from 'react-apollo';
+import gql from 'graphql-tag';
+
+const getVersion = gql`
+  {
+    schemaSha
+  }
+`;
+
+let lastValue = null;
+
+export const Version = () => (
+  <Subscription subscription={getVersion}>
+    {({ loading, error, data }) => {
+      if (loading || error) {
+        return null;
+      }
+
+      const newValue = data.schemaSha;
+      if (lastValue == null) {
+        lastValue = newValue;
+        console.log(lastValue);
+        console.log(newValue);
+      } else if (newValue !== lastValue) {
+        lastValue = newValue;
+        window.location.reload();
+      }
+
+      return newValue;
+    }}
+  </Subscription>
+);
+
+export default Version;

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -118,6 +118,24 @@
               "deprecationReason": null
             },
             {
+              "name": "schemaSha",
+              "description": "Get current sha",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "tweets",
               "description": "Tweets from MojoTech",
               "args": [
@@ -3052,6 +3070,24 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "Event",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "schemaSha",
+              "description": "Updated SHA value",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },

--- a/app/workers/sha_poller_worker.rb
+++ b/app/workers/sha_poller_worker.rb
@@ -1,0 +1,17 @@
+# Polls weather for subscribed locations
+class ShaPollerWorker
+  include Sidekiq::Worker
+  include Sidekiq::Repeat::Repeatable
+
+  repeat { hourly.minute_of_hour(0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55) }
+
+  def perform
+    logger.info "Running sha poll"
+
+    Helios2Schema.subscriptions.trigger(
+      "schemaShaPublished",
+      {},
+      AppEnv['HEROKU_SLUG_COMMIT']
+    )
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -109,6 +109,9 @@ type Query {
   # Location running the app
   primaryLocation: Location!
 
+  # Get current sha
+  schemaSha: String!
+
   # Tweets from MojoTech
   tweets: [MojoTweet!]!
 }
@@ -124,6 +127,9 @@ type Subscription {
 
   # An event was published to the API
   eventPublished: Event!
+
+  # Updated SHA value
+  schemaSha: String!
 
   # Latest weather data retrieved
   weatherPublished(latitude: Float!, longitude: Float!): Weather!


### PR DESCRIPTION
### Files Edited
- app/graphql/types/query_type.rb
- app/javascript/components/app.jsx
- app/javascript/components/get-version.jsx

### Description
Implemented a new query to attain a current (dummy) SHA value and conditions to compare with a new (dummy) SHA value. If the two do not match, then there is an update to the application; the page will refresh and the recorded current SHA is overwritten by the new SHA value.

The query gets the value stored in a new variable in the .env file. Ex: `HEROKU_SLUG_COMMIT=foosomething`, which serves as the current dummy SHA value.