### PR TITLE
check diff on schema.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,11 @@ jobs:
       - run: bundle exec rake db:create
       - run: bundle exec rake db:schema:load
 
+      - run:
+          name: run diff on schema.json
+          command: |
+            git diff --quiet schema.graphql
+
       # run tests!
       - run:
           name: run tests


### PR DESCRIPTION
**Ticket description: **

We sometimes forget to dump the graphql schema from rails leaving schema.json in a broken state until future javascript changes. We should catch this automatically with a CircleCI step that runs the schema dump and asserts the schema files were not changed

**Changes: **

Add shell script to check if schema.json is included in git diff