### PR TITLE
feat: server broadcasting to subscribed clients with updated SHA value

### DIFF
--- a/app/graphql/types/subscription_type.rb
+++ b/app/graphql/types/subscription_type.rb
@@ -14,4 +14,8 @@ class Types::SubscriptionType < Types::BaseObject
   field :announcement_published, Types::AnnouncementType, description: "An announcement was published"
 
   def announcement_published; end
+
+  field :deployment_sha, String, description: "Updated SHA value"
+
+  def deployment_sha; end
 end

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -3072,6 +3072,24 @@
               "deprecationReason": null
             },
             {
+              "name": "deploymentSha",
+              "description": "Updated SHA value",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "eventPublished",
               "description": "An event was published to the API",
               "args": [

--- a/app/workers/sha_poller_worker.rb
+++ b/app/workers/sha_poller_worker.rb
@@ -1,0 +1,17 @@
+# Polls deployment sha for subscribed clients
+class ShaPollerWorker
+  include Sidekiq::Worker
+  include Sidekiq::Repeat::Repeatable
+
+  repeat { hourly.minute_of_hour(0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55) }
+
+  def perform
+    logger.info "Running sha poll"
+
+    Helios2Schema.subscriptions.trigger(
+      "deploymentSha",
+      {},
+      AppEnv['HEROKU_SLUG_COMMIT'] || "N/A"
+    )
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -128,6 +128,9 @@ type Subscription {
   # An announcement was published
   announcementPublished: Announcement!
 
+  # Updated SHA value
+  deploymentSha: String!
+
   # An event was published to the API
   eventPublished: Event!
 

--- a/spec/workers/sha_poller_worker_spec.rb
+++ b/spec/workers/sha_poller_worker_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe ShaPollerWorker, type: :worker do
+  before {
+    allow(AppEnv).to receive(:[]).with('HEROKU_SLUG_COMMIT') { nil }
+  }
+
+  describe "SHA Poll Worker" do
+    context "should publish the deployed SHA value" do
+      it "will publish deployed SHA when triggered" do
+        expect(Helios2Schema.subscriptions).to(
+          receive(:trigger).with(
+            "deploymentSha",
+            {},
+            "N/A"
+          )
+        )
+        ShaPollerWorker.new.perform
+      end
+    end
+  end
+end


### PR DESCRIPTION
The file included in this PR create a subscription type which updates the GraphQL database, as well as sends a broadcast to subscribed clients with an updated SHA value. The code in this PR is server side only.