### PR TITLE
feat: client receives deployed sha value via subscriptions and performs comparison with current sharing for refresh

### DIFF
--- a/app/javascript/components/app.jsx
+++ b/app/javascript/components/app.jsx
@@ -14,6 +14,7 @@ import { getMainDefinition } from 'apollo-utilities';
 import ActionCableLink from 'graphql-ruby-client/subscriptions/ActionCableLink';
 import { persistCache } from 'apollo-cache-persist';
 import WidgetController from '@components/widget-controller';
+import versionCompare from '@components/version-compare';
 import helioSchema from '@javascript/schema.json';
 import GlobalStyle from '../styles';
 
@@ -72,6 +73,8 @@ const client = new ApolloClient({
     },
   },
 });
+
+versionCompare(client);
 
 const App = () => (
   <ApolloProvider client={client}>

--- a/app/javascript/components/version-compare.jsx
+++ b/app/javascript/components/version-compare.jsx
@@ -1,0 +1,29 @@
+import gql from 'graphql-tag';
+
+const getVersion = gql`
+  subscription onDeploymentSha {
+    deploymentSha
+  }
+`;
+
+let lastValue = null;
+
+const versionCompare = client =>
+  client.subscribe({ query: getVersion }).subscribe({
+    next: ({ data: { deploymentSha } }) => {
+      if (lastValue == null) {
+        lastValue = deploymentSha;
+      } else if (deploymentSha !== lastValue) {
+        lastValue = deploymentSha;
+        window.location.reload();
+      }
+    },
+    error: () => {
+      console.log(`Caused Error!`);
+    },
+    complete: () => {
+      console.log(`We completed!`);
+    },
+  });
+
+export default versionCompare;


### PR DESCRIPTION
This branch consists of the client-side code that queries the GraphQL database for the deployed SHA value broadcasted by the server. The client then makes the comparison of its current SHA value with the updated queried value. This comparison occurs every five minutes per the server's SHA poller worker. If the SHA values are the same, nothing happens. If they are different, then the page reloads to an updated version of Helios 2.