### PR TITLE
chore: remove unnecessary remounts of WidgetController on render

### DIFF
--- a/app/javascript/components/app.jsx
+++ b/app/javascript/components/app.jsx
@@ -83,7 +83,7 @@ const App = () => (
       <Switch>
         <Route
           path="/:city_name"
-          component={routeProps => (
+          render={routeProps => (
             <WidgetController
               client={client}
               cityName={routeProps.match.params.city_name}


### PR DESCRIPTION
**Description**

Passing WidgetController to the `component` prop of Route via an inline function causes unmounting and remounting of the component rather than being updated. Use of the `render` property fixes this issue.

Source: https://reactrouter.com/web/api/Route/component