### PR TITLE
chore: add helper dependency and aliases to testing environment

### DIFF
--- a/__mocks__/emptyMock.js
+++ b/__mocks__/emptyMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
       "^@messages(.*)$": "<rootDir>/app/javascript/components/widgets/messages$1",
       "^@numbers(.*)$": "<rootDir>/app/javascript/components/widgets/numbers$1",
       "^@weather(.*)$": "<rootDir>/app/javascript/components/widgets/weather$1",
+      "^@twitter(.*)$": "<rootDir>/app/javascript/components/widgets/twitter$1",
       "^@hocs(.*)$": "<rootDir>/app/javascript/components/hocs$1",
       "^@assets(.*)$": "<rootDir>/app/assets$1",
       "^@images(.*)$": "<rootDir>/app/assets/images$1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     ],
     "moduleNameMapper": {
       "\\.(png|jpg|gif|ttf|eot|svg)$": "<rootDir>/__mocks__/fileMock.js",
+      "react-hls-player": "<rootDir>/__mocks__/emptyMock.js",
       "^@root(.*)$": "<rootDir>/$1",
       "^@app(.*)$": "<rootDir>/app$1",
       "^@javascript(.*)$": "<rootDir>/app/javascript$1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "regenerator-runtime": "^0.13.7",
     "resurrect-js": "^1.0.1",
     "styled-components": "^4.0.0",
-    "styled-normalize": "^4.0.0"
+    "styled-normalize": "^4.0.0",
+    "unfetch": "^4.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11684,6 +11684,11 @@ unbox-primitive@^1.0.0:
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
 
+unfetch@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
+  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"


### PR DESCRIPTION
**Description**

1. Adds @twitter alias to the testing environment so the twitter Widget can be imported properly
2. Adds the unfetch dependency to emulate fetch in the testing environment
3. Adds react-hls-player alias mapped to a mock import for the testing environment