### PR TITLE
 feat:display an error message when widget is  empty array

### DIFF
--- a/app/javascript/components/widget-controller.jsx
+++ b/app/javascript/components/widget-controller.jsx
@@ -2,10 +2,12 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
+import { isEmpty, pathOr } from 'ramda';
 import {
   WidgetDisplay,
   LoadingDisplay,
   DisconnectedDisplay,
+  WidgetDisabledDisplay,
   getWidgetDisplay,
 } from '@components/widget-display';
 import WidgetTransitionControls from '@components/widget-transition-controls';
@@ -71,6 +73,11 @@ export const WidgetController = ({ client, cityName }) => {
           // eslint-disable-next-line
           console.error(error);
           return <DisconnectedDisplay cityName={cityName} error={error} />;
+        }
+
+        const widget = pathOr([], ['location', 'widgets', 'enabled'], data);
+        if (isEmpty(widget)) {
+          return <WidgetDisabledDisplay />;
         }
 
         return (

--- a/app/javascript/components/widget-display.jsx
+++ b/app/javascript/components/widget-display.jsx
@@ -2,7 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import styled from 'styled-components';
-import { DisconnectedMessage, LoadingMessage } from '@messages/message';
+import {
+  DisconnectedMessage,
+  LoadingMessage,
+  WidgetDisabledMessage,
+} from '@messages/message';
 import FullPanel from '@components/full-panel';
 import SidePanel, { getSidePanel } from '@components/side-panel';
 import Twitter from '@widgets/twitter';
@@ -149,4 +153,18 @@ DisconnectedDisplay.defaultProps = {
   error: false,
 };
 
+export const WidgetDisabledDisplay = () => (
+  <Wrapper>
+    <FullPanel>
+      <WidgetDisabledMessage />
+    </FullPanel>
+    <SidePanel
+      widgets={[]}
+      selectedWidgetId={0}
+      showWeather={false}
+      totalTime={0}
+      isPaused={false}
+    />
+  </Wrapper>
+);
 export default withFragment(WidgetDisplay);

--- a/app/javascript/components/widgets/messages/message.jsx
+++ b/app/javascript/components/widgets/messages/message.jsx
@@ -11,6 +11,9 @@ export const DisconnectedMessage = () => (
 );
 export const WeatherLoadingMessage = () => <WeatherMessage />;
 export const WeatherDisconnectedMessage = () => <WeatherMessage />;
+export const WidgetDisabledMessage = () => (
+  <Message message="No widget enabled" />
+);
 
 const MessageDisplay = styled(GreySubText)`
   font-size: ${fontSizes.medium};


### PR DESCRIPTION
 Display an error message "No widget enabled" if a widgets query for a location returns with an empty array of widgets.
https://www.pivotaltracker.com/story/show/178526431
<img width="343" alt="Screen Shot 2021-07-13 at 11 46 30 AM" src="https://user-images.githubusercontent.com/48374644/125492743-8adf8fb0-f19f-4d2f-be8b-898351cf991b.png">
