### PR TITLE
fix null value issue for windGust

### DIFF
--- a/app/graphql/types/weather_type.rb
+++ b/app/graphql/types/weather_type.rb
@@ -65,7 +65,7 @@ class Types::WeatherHourlyDataType < Types::WeatherObject
   field :humidity, Int
   field :pressure, Int
   field :wind_speed, Float
-  field :wind_gust, Float
+  field :wind_gust, Float, null: true
   field :wind_deg, Int
   field :clouds, Int
   field :uvi, Int

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -1327,13 +1327,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/schema.graphql
+++ b/schema.graphql
@@ -254,7 +254,7 @@ type WeatherHourlyData {
   visibility: Int!
   weather: WeatherInfoData!
   windDeg: Int!
-  windGust: Float!
+  windGust: Float
   windSpeed: Float!
 }
 


### PR DESCRIPTION
The response from openweather API for current weather may have a null value for windGust.  There was an error that mentioned "cannot return null value for null-nullable field" since  our graphql API does not allow a null value in our schema.
https://www.pivotaltracker.com/story/show/178831309