### PR TITLE
fix:mark null in graphql types for nullable values in the openweather api response

### DIFF
--- a/app/graphql/types/weather_type.rb
+++ b/app/graphql/types/weather_type.rb
@@ -43,7 +43,7 @@ class Types::WeatherDailyDataType < Types::WeatherObject
   field :sunrise, Types::UnixDateTimeType
   field :sunset, Types::UnixDateTimeType
   field "precipProbability", Float, hash_key: "pop"
-  field :rain, Float
+  field :rain, Float, null: true
   field :temp, Types::WeatherTemperatureDataType
   field :feels_like, Types::WeatherApparentTemperatureDataType
   field :dew_point, Int
@@ -88,7 +88,7 @@ class Types::WeatherCurrentlyDetailType < Types::WeatherObject
   field "humidity", Int
   field "pressure", Int
   field "wind_speed", Float
-  field "wind_gust", Float
+  field "wind_gust", Float, null: true
   field "wind_deg", Int
   field "clouds", Float
   field "uvi", Int

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -898,13 +898,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1480,13 +1476,9 @@
 
               ],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/schema.graphql
+++ b/schema.graphql
@@ -229,7 +229,7 @@ type WeatherCurrentlyDetail {
   visibility: Int!
   weather: WeatherInfoData!
   windDeg: Int!
-  windGust: Float!
+  windGust: Float
   windSpeed: Float!
 }
 
@@ -240,7 +240,7 @@ type WeatherDailyData {
   humidity: Int!
   precipProbability: Float!
   pressure: Int!
-  rain: Float!
+  rain: Float
   sunrise: UnixDateTime!
   sunset: UnixDateTime!
   temp: WeatherTemperatureData!


### PR DESCRIPTION
Follow-up task into the other nullable fields from openweathermap API. 
https://www.pivotaltracker.com/story/show/178831309