### PR TITLE
fix : fresh page load does not show weather

### DIFF
--- a/app/javascript/components/widget-controller.jsx
+++ b/app/javascript/components/widget-controller.jsx
@@ -55,14 +55,6 @@ export const WidgetController = ({ client, cityName }) => {
       query={getWidgets}
       variables={{ id: newWidgetId, cityName }}
       fetchPolicy={fetchPolicy}
-      onCompleted={response => {
-        const {
-          location: {
-            widgets: { byIdOrFirst: current },
-          },
-        } = response;
-        setNewWidgetId(current.id);
-      }}
     >
       {({ loading, error, data }) => {
         if (loading) {


### PR DESCRIPTION
This bug is caused because onCompleted callbacks will be called many times . Removing it calls setNewWidgetId once and fixes the issue.