### PR TITLE
fix: added unique key prop for each displayed cam URL

### DIFF
--- a/app/javascript/components/widgets/traffic/panel.jsx
+++ b/app/javascript/components/widgets/traffic/panel.jsx
@@ -113,7 +113,7 @@ const Traffic = ({ cityName }) => (
           </Row>
           <Notice>Images from:</Notice>
           {getUniqUrls(trafficCams).map(url => (
-            <Notice>{url}</Notice>
+            <Notice key={url}>{url}</Notice>
           ))}
         </>
       );


### PR DESCRIPTION
Fix console warning: "Warning: Each child in a list should have a unique "key" prop." for traffic widget panel
