### PR TITLE
Bb/weathercorner css

### DIFF
--- a/app/javascript/components/time.jsx
+++ b/app/javascript/components/time.jsx
@@ -19,6 +19,7 @@ const AMPM = styled.div`
   font-size: ${fontSizes.medium};
   font-family: ${fonts.extended};
   margin-left: 11px;
+  line-height: 45px;
 `;
 
 const TimeValue = styled(Row)`

--- a/app/javascript/components/time.jsx
+++ b/app/javascript/components/time.jsx
@@ -14,7 +14,6 @@ const HourMin = styled.div`
   font-family: ${fonts.extended};
   font-weight: ${weights.regular};
   position: relative;
-  top: 8px;
 `;
 
 const AMPM = styled.div`

--- a/app/javascript/components/time.jsx
+++ b/app/javascript/components/time.jsx
@@ -13,7 +13,6 @@ const HourMin = styled.div`
   font-size: ${fontSizes.xlarge};
   font-family: ${fonts.extended};
   font-weight: ${weights.regular};
-  position: relative;
 `;
 
 const AMPM = styled.div`

--- a/app/javascript/components/weather-corner.jsx
+++ b/app/javascript/components/weather-corner.jsx
@@ -27,18 +27,11 @@ const CornerWeather = gql`
   ${getCurrentIcon}
 `;
 
-const Column = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-`;
-
 const TempText = styled.div`
   color: ${colors.white};
   font-size: ${fontSizes.xlarge};
   font-weight: ${weights.regular};
   font-family: ${fonts.extended};
-  margin-top: 15px;
 `;
 
 const SkyIconWrapper = styled.div`
@@ -55,16 +48,14 @@ class WeatherCorner extends React.Component {
     const { location } = this.props;
     const { weather } = location;
     return (
-      <Column>
-        <Row>
-          <SkyIconWrapper>
-            <MediumSkyIcon icon={weather.current.weather.icon} />
-          </SkyIconWrapper>
-          <TempText>
-            <CurrentTemp {...{ weather }} />
-          </TempText>
-        </Row>
-      </Column>
+      <Row>
+        <SkyIconWrapper>
+          <MediumSkyIcon icon={weather.current.weather.icon} />
+        </SkyIconWrapper>
+        <TempText>
+          <CurrentTemp {...{ weather }} />
+        </TempText>
+      </Row>
     );
   }
 }

--- a/app/javascript/components/weather-corner.jsx
+++ b/app/javascript/components/weather-corner.jsx
@@ -39,8 +39,7 @@ const TempText = styled.div`
 `;
 
 const SkyIconWrapper = styled.div`
-  margin-top: 35px;
-  margin-right: 24px;
+  margin-bottom: 5px;
 `;
 
 class WeatherCorner extends React.Component {

--- a/app/javascript/components/weather-corner.jsx
+++ b/app/javascript/components/weather-corner.jsx
@@ -27,6 +27,10 @@ const CornerWeather = gql`
   ${getCurrentIcon}
 `;
 
+const BottomLineRow = styled(Row)`
+  align-items: flex-end;
+`;
+
 const TempText = styled.div`
   color: ${colors.white};
   font-size: ${fontSizes.xlarge};
@@ -48,14 +52,14 @@ class WeatherCorner extends React.Component {
     const { location } = this.props;
     const { weather } = location;
     return (
-      <Row>
+      <BottomLineRow>
         <SkyIconWrapper>
           <MediumSkyIcon icon={weather.current.weather.icon} />
         </SkyIconWrapper>
         <TempText>
           <CurrentTemp {...{ weather }} />
         </TempText>
-      </Row>
+      </BottomLineRow>
     );
   }
 }


### PR DESCRIPTION
Fixed styling issue where weather corner's div was unintentionally taller than the time + AM/PM div.. This caused all widget's side panel elements (besides the weather widget who doesn't render weathercorner) to be shifted downwards by that height offset.

ticket id: 179167655
Description:
"Weather corner's styling doesn't apply to the weather widget (which neglects displaying weather in the top corner). This results in the rest of the weather widget's sidepanel styling to be offset."