### PR TITLE
fix: Remove extra 'images from' URL from cam page

### DIFF
--- a/app/javascript/components/widgets/traffic/panel.jsx
+++ b/app/javascript/components/widgets/traffic/panel.jsx
@@ -99,7 +99,7 @@ const Traffic = ({ cityName, startTimer }) => (
       const [firstColumn, secondColumn] = splitAt(columnSize, trafficCams);
       const getUniqUrls = compose(
         uniq,
-        map(cam => new URL(cam.url).origin),
+        map(cam => new URL(cam.url).hostname),
       );
 
       return (


### PR DESCRIPTION
ID: #181116668

The Providence traffic cam page was showing 2 "images from" URLs for http and https. It will only show the https URL from now on.