### PR TITLE
feat: blocks fall again after cycle

### DIFF
--- a/app/javascript/components/widgets/numbers/panel.jsx
+++ b/app/javascript/components/widgets/numbers/panel.jsx
@@ -151,6 +151,7 @@ const Numbers = ({ startTimer }) => (
       }
 
       const { count } = data.events;
+
       return (
         <>
           <Count>
@@ -163,9 +164,7 @@ const Numbers = ({ startTimer }) => (
                     if (!subscriptionData.data) {
                       return prev;
                     }
-
                     const { source } = subscriptionData.data.eventPublished;
-
                     return over(
                       lensPath(['events', 'count', source]),
                       inc,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,4 +61,7 @@ Rails.application.configure do
 
   # allow LAN IPs access to the console
   config.web_console.whitelisted_ips = %w[127.0.0.1 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16]
+
+  # Disabling cors check in dev environment
+  config.hosts << "helios-event-simulate.local"
 end

--- a/lib/tasks/simulate.rake
+++ b/lib/tasks/simulate.rake
@@ -1,9 +1,8 @@
 namespace :simulate do
   desc "Simulates opening a new pull request on github"
   task :pull_request, [:count] => :environment do |_t, args|
-    post_github_event('pull_request', render_new_pull_request_json)
-    disable_github_authentication
     args.with_defaults(count: 1)
+    disable_github_authentication
     args[:count].to_i.times { post_github_event('pull_request', render_new_pull_request_json) }
   end
 

--- a/lib/tasks/simulate.rake
+++ b/lib/tasks/simulate.rake
@@ -35,6 +35,7 @@ namespace :simulate do
 
   def post_github_event(event, params)
     session = ActionDispatch::Integration::Session.new(Rails.application)
+    session.host = "helios-event-simulate.local"
     resp = session.post(
       "/web_hooks/github",
       params: params,
@@ -49,6 +50,7 @@ namespace :simulate do
   def post_slack_event(params)
     ENV['SLACK_VERIFICATION_TOKEN'] = 'Sim-123456'
     session = ActionDispatch::Integration::Session.new(Rails.application)
+    session.host = "helios-event-simulate.local"
     resp = session.post(
       "/web_hooks/slack_event",
       params: params,


### PR DESCRIPTION
ID: #181114917

Each serialized block gets a random y position. This causes them to fall from the top each time the slack/github events page mounts.