### PR TITLE
refactor: make timezone field 2 words

### DIFF
--- a/app/graphql/types/location_type.rb
+++ b/app/graphql/types/location_type.rb
@@ -4,7 +4,7 @@ class Types::LocationType < Types::BaseObject
   field "id", ID
   field "latitude", Float
   field "longitude", Float
-  field "timezone", String, method: :time_zone
+  field "time_zone", String
   field "city_name", String
   field "is_primary", Boolean, method: :primary?
   field "weather", Types::WeatherType

--- a/app/graphql/types/weather_type.rb
+++ b/app/graphql/types/weather_type.rb
@@ -98,7 +98,7 @@ end
 class Types::WeatherType < Types::WeatherObject
   field "lat", Float
   field "lon", Float
-  field "timezone", String
+  field "time_zone", String, hash_key: :timezone
   field "current", Types::WeatherCurrentlyDetailType
   field "minutely", [Types::WeatherMinutelyDataType]
   field "hourly", [Types::WeatherHourlyDataType]

--- a/app/javascript/components/date.jsx
+++ b/app/javascript/components/date.jsx
@@ -9,7 +9,7 @@ import withFragment from './hocs/with-fragment';
 
 export const getTimeZone = gql`
   fragment Date on Location {
-    timezone
+    timeZone
   }
 `;
 export const DateText = styled.div`

--- a/app/javascript/components/hocs/with-fragment.test.jsx
+++ b/app/javascript/components/hocs/with-fragment.test.jsx
@@ -20,12 +20,12 @@ const locationQuery = gql`
     ...TimeHero
   }
   fragment TimeHero on Location {
-    timezone
+    timeZone
   }
 `;
 
 const locationData = {
-  timezone: 'America/Denver',
+  timeZone: 'America/Denver',
   wifiName: 'test',
   wifiPassword: 'test1234',
   bathroomCode: '1234',
@@ -36,7 +36,7 @@ describe('withFragment higher order component', () => {
   it('filters properties correctly', () => {
     const testComponent = ({ location }) => {
       expect(location).toEqual({
-        timezone: 'America/Denver',
+        timeZone: 'America/Denver',
         wifiName: 'test',
         wifiPassword: 'test1234',
         bathroomCode: '1234',

--- a/app/javascript/components/time-hero.jsx
+++ b/app/javascript/components/time-hero.jsx
@@ -7,7 +7,7 @@ import withFragment from './hocs/with-fragment';
 
 export const getTimeHero = gql`
   fragment TimeHero on Location {
-    timezone
+    timeZone
   }
 `;
 

--- a/app/javascript/components/widgets/weather/sunrise-sunset.jsx
+++ b/app/javascript/components/widgets/weather/sunrise-sunset.jsx
@@ -60,7 +60,7 @@ export const getSunriseSunsetWeather = gql`
 
 export const getSunriseSunsetLocation = gql`
   fragment SunriseSunsetLocation on Location {
-    timezone
+    timeZone
     moonPhase
     cityName
     solarCycles {

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -336,7 +336,7 @@
               "deprecationReason": null
             },
             {
-              "name": "timezone",
+              "name": "timeZone",
               "description": null,
               "args": [
 
@@ -645,7 +645,7 @@
               "deprecationReason": null
             },
             {
-              "name": "timezone",
+              "name": "timeZone",
               "description": null,
               "args": [
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -94,7 +94,7 @@ type Location {
   longitude: Float!
   moonPhase: Float!
   solarCycles: [SolarCycle!]!
-  timezone: String!
+  timeZone: String!
   trafficCams: [TrafficCam!]!
   weather: Weather!
   widgets: WidgetCollection!
@@ -251,7 +251,7 @@ type Weather {
   minutely: [WeatherMinutelyData!]!
   moonPhase: Float! @deprecated(reason: "Moved to Location")
   offset: Int!
-  timezone: String!
+  timeZone: String!
 }
 
 type WeatherApparentTemperatureData {


### PR DESCRIPTION
The Rails schema had timezone as 1 word and since it's 2 words I switched it to "time_zone" to keep it consistent with other fields.