### PR TITLE
fix: change location id type from announcements

### DIFF
--- a/app/graphql/types/announcement_type.rb
+++ b/app/graphql/types/announcement_type.rb
@@ -13,5 +13,5 @@ class Types::AnnouncementType < Types::BaseObject
   field "people", String
   field "company", String
   field "announcement_id", String
-  field "location_id", String
+  field "location_id", Integer
 end

--- a/app/graphql/types/widget_type.rb
+++ b/app/graphql/types/widget_type.rb
@@ -10,7 +10,7 @@ module Types::WidgetType
   field "position", Integer, null: false
   field "sidebar_text", String, null: true
   field "show_weather", Boolean, null: true
-  field "location_id", String, null: false
+  field "location_id", Integer, null: false
 
   definition_methods do
     def resolve_type(obj, _ctx)

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -1929,7 +1929,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Int",
                   "ofType": null
                 }
               },
@@ -2153,7 +2153,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Int",
                   "ofType": null
                 }
               },
@@ -4287,7 +4287,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Int",
                   "ofType": null
                 }
               },
@@ -4422,7 +4422,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Int",
                   "ofType": null
                 }
               },
@@ -4575,7 +4575,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Int",
                   "ofType": null
                 }
               },
@@ -4773,7 +4773,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Int",
                   "ofType": null
                 }
               },
@@ -4908,7 +4908,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Int",
                   "ofType": null
                 }
               },
@@ -5069,7 +5069,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Int",
                   "ofType": null
                 }
               },

--- a/db/migrate/20220302163416_change_location_id_type_from_announcements.rb
+++ b/db/migrate/20220302163416_change_location_id_type_from_announcements.rb
@@ -1,0 +1,9 @@
+class ChangeLocationIdTypeFromAnnouncements < ActiveRecord::Migration[6.0]
+  def up
+    change_column :announcements, :location_id, :integer
+  end
+
+  def down
+    change_column :announcements, :location_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_17_225447) do
+ActiveRecord::Schema.define(version: 2022_03_02_163416) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 2022_02_17_225447) do
     t.string "people", null: false
     t.string "company"
     t.string "announcement_id", null: false
-    t.string "location_id"
+    t.integer "location_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["location_id"], name: "index_announcements_on_location_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -2,7 +2,7 @@ type Announcement {
   announcementId: String!
   company: String!
   id: ID!
-  locationId: String!
+  locationId: Int!
   message: String!
   people: String!
   publishOn: UTCDateTime!
@@ -61,7 +61,7 @@ enum EventSource {
 type EventsWidget implements Widget {
   durationSeconds: Int!
   id: Int!
-  locationId: String!
+  locationId: Int!
   name: String!
   position: Int!
   showWeather: Boolean
@@ -75,7 +75,7 @@ type GuestsWidget implements Widget {
   dayAnnouncements: [Announcement!]!
   durationSeconds: Int!
   id: Int!
-  locationId: String!
+  locationId: Int!
   name: String!
   position: Int!
   showWeather: Boolean
@@ -123,7 +123,7 @@ type NumbersWidget implements Widget {
   """
   events(after: String, type: EventSource): EventCollection!
   id: Int!
-  locationId: String!
+  locationId: Int!
   name: String!
   position: Int!
   showWeather: Boolean
@@ -194,7 +194,7 @@ type TrafficCam {
 type TrafficWidget implements Widget {
   durationSeconds: Int!
   id: Int!
-  locationId: String!
+  locationId: Int!
   name: String!
   position: Int!
   showWeather: Boolean
@@ -226,7 +226,7 @@ type TweetUser {
 type TwitterWidget implements Widget {
   durationSeconds: Int!
   id: Int!
-  locationId: String!
+  locationId: Int!
   name: String!
   position: Int!
   showWeather: Boolean
@@ -338,7 +338,7 @@ type WeatherTemperatureData {
 type WeatherWidget implements Widget {
   durationSeconds: Int!
   id: Int!
-  locationId: String!
+  locationId: Int!
   name: String!
   position: Int!
   showWeather: Boolean
@@ -356,7 +356,7 @@ A single tab or panel of Helios
 interface Widget {
   durationSeconds: Int!
   id: Int!
-  locationId: String!
+  locationId: Int!
   name: String!
   position: Int!
   showWeather: Boolean


### PR DESCRIPTION
changed "location_id" type from string to integer because it was throwing "ArgumentError" when accessing the location_id from Announcement table from Phoenix.  location_id has to be set to an integer, not a string.