### PR TITLE
fix: proptypes with incorrect casing of timeZone

### DIFF
--- a/app/javascript/components/date.jsx
+++ b/app/javascript/components/date.jsx
@@ -25,7 +25,7 @@ export class Date extends React.Component {
     loading: PropTypes.bool,
     error: PropTypes.bool,
     location: PropTypes.shape({
-      timezone: PropTypes.string,
+      timeZone: PropTypes.string,
     }).isRequired,
   };
 
@@ -37,13 +37,13 @@ export class Date extends React.Component {
   state = { date: null };
 
   componentDidMount() {
-    if (this.timezone(this.props)) {
+    if (this.timeZone(this.props)) {
       this.startDateTimer();
     }
   }
 
   componentDidUpdate(prevProps) {
-    if (this.timezone(this.props) && !this.timezone(prevProps)) {
+    if (this.timeZone(this.props) && !this.timeZone(prevProps)) {
       this.startDateTimer();
     }
   }
@@ -55,10 +55,10 @@ export class Date extends React.Component {
   }
 
   setDate = () => {
-    this.setState({ date: dateForTimezone(this.timezone(this.props)) });
+    this.setState({ date: dateForTimezone(this.timeZone(this.props)) });
   };
 
-  timezone = props => (props.location ? props.location.timezone : null);
+  timeZone = props => (props.location ? props.location.timeZone : null);
 
   startDateTimer = () => {
     this.setDate();
@@ -76,6 +76,7 @@ export class Date extends React.Component {
     }
 
     const { date } = this.state;
+
     if (!date) {
       return null;
     }

--- a/app/javascript/components/time.jsx
+++ b/app/javascript/components/time.jsx
@@ -32,18 +32,18 @@ const TimeValue = styled(Row)`
 export class Time extends React.Component {
   static propTypes = {
     location: PropTypes.shape({
-      timezone: PropTypes.string.isRequired,
+      timeZone: PropTypes.string.isRequired,
     }).isRequired,
   };
 
   constructor(props) {
     super(props);
-    this.state = { time: timeForTimezone(props.location.timezone) };
+    this.state = { time: timeForTimezone(props.location.timeZone) };
   }
 
   componentDidMount() {
     this.intervalId = setInterval(() => {
-      this.setState({ time: timeForTimezone(this.props.location.timezone) });
+      this.setState({ time: timeForTimezone(this.props.location.timeZone) });
     }, 10000);
   }
 
@@ -68,7 +68,7 @@ export class Time extends React.Component {
 
 Time.propTypes = {
   location: PropTypes.shape({
-    timezone: PropTypes.string.isRequired,
+    timeZone: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/app/javascript/components/widgets/weather/semi-circle.jsx
+++ b/app/javascript/components/widgets/weather/semi-circle.jsx
@@ -64,7 +64,7 @@ export class SemiCircle extends React.Component {
     endTime: PropTypes.instanceOf(Date).isRequired,
     width: PropTypes.string.isRequired,
     height: PropTypes.string.isRequired,
-    timezone: PropTypes.string.isRequired,
+    timeZone: PropTypes.string.isRequired,
     cityName: PropTypes.string.isRequired,
     paddingLeft: PropTypes.number,
     paddingTop: PropTypes.number,
@@ -90,7 +90,7 @@ export class SemiCircle extends React.Component {
     this.state = {
       remainingTime: timeDiffInMinutes(
         this.props.endTime,
-        timeAndDateForTimezone(this.props.timezone),
+        timeAndDateForTimezone(this.props.timeZone),
       ),
     };
   }
@@ -100,7 +100,7 @@ export class SemiCircle extends React.Component {
       this.setState({
         remainingTime: timeDiffInMinutes(
           this.props.endTime,
-          timeAndDateForTimezone(this.props.timezone),
+          timeAndDateForTimezone(this.props.timeZone),
         ),
       });
     }, 10000);

--- a/app/javascript/components/widgets/weather/sunrise-sunset.jsx
+++ b/app/javascript/components/widgets/weather/sunrise-sunset.jsx
@@ -71,7 +71,7 @@ export const getSunriseSunsetLocation = gql`
 `;
 
 export const SunriseSunset = ({ location, weather }) => {
-  const { solarCycles, timezone, cityName, moonPhase } = location;
+  const { solarCycles, timeZone, cityName, moonPhase } = location;
 
   const currDate = new Date();
 
@@ -108,7 +108,7 @@ export const SunriseSunset = ({ location, weather }) => {
         endTime={new Date(endTime.time)}
         width={leftPanelWidth}
         height={containerHeight}
-        timezone={timezone}
+        timeZone={timeZone}
         cityName={cityName}
         nightMode={isNight}
         moonPhase={moonPhase}
@@ -127,7 +127,7 @@ export const SunriseSunset = ({ location, weather }) => {
 
 SunriseSunset.propTypes = {
   location: PropTypes.shape({
-    timezone: PropTypes.string.isRequired,
+    timeZone: PropTypes.string.isRequired,
     moonPhase: PropTypes.number.isRequired,
     cityName: PropTypes.string.isRequired,
     solarCycles: PropTypes.arrayOf(


### PR DESCRIPTION
The time was defaulting to UTC due to propTypes and prop names using `timezone` instead of `timeZone` on the frontend. 