### PR TITLE
fix: force ssl in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
Users were getting a CORS error when accessing the HTTP domain. All HTTP requests will now be redirected to HTTPS in production.