### PR TITLE
fix: fields to ecto timestamps in schemas

### DIFF
--- a/server-phoenix/lib/helios/announcement.ex
+++ b/server-phoenix/lib/helios/announcement.ex
@@ -11,8 +11,7 @@ defmodule Helios.Announcement do
     field :people, :string, presence: true
     field :company, :string
     field :announcement_id, :string, presence: true
-    field :created_at, :utc_datetime, presence: true
-    field :updated_at, :utc_datetime, presence: true
+    timestamps([inserted_at: :created_at, type: :utc_datetime])
 
     belongs_to :location, Location
   end

--- a/server-phoenix/lib/helios/location.ex
+++ b/server-phoenix/lib/helios/location.ex
@@ -8,11 +8,10 @@ defmodule Helios.Location do
     field :longitude, :float, presence: true
     field :city_name, :string, presence: true, uniqueness: true
     field :time_zone, :string, presence: true
-    field :created_at, :utc_datetime, presence: true
-    field :updated_at, :utc_datetime, presence: true
     field :wifi_name, :string
     field :wifi_password, :string
     field :bathroom_code, :string
+    timestamps([inserted_at: :created_at, type: :utc_datetime])
 
     has_many :announcements, Helios.Announcement
     has_many :traffic_cams, Helios.TrafficCam

--- a/server-phoenix/lib/helios/traffic_cam.ex
+++ b/server-phoenix/lib/helios/traffic_cam.ex
@@ -6,9 +6,8 @@ defmodule Helios.TrafficCam do
   schema "traffic_cams" do
     field :title, :string, presence: true
     field :url, :string, presence: true
-    field :created_at, :utc_datetime, presence: true
-    field :updated_at, :utc_datetime, presence: true
     field :feed_format, :string, presence: true
+    timestamps([inserted_at: :created_at, type: :utc_datetime])
 
     belongs_to :location, Location
   end

--- a/server-phoenix/lib/helios/widget.ex
+++ b/server-phoenix/lib/helios/widget.ex
@@ -10,12 +10,11 @@ defmodule Helios.Widget do
     field :enabled, :boolean, presence: true
     field :duration_seconds, :integer, presence: true
     field :position, :integer, presence: true
-    field :created_at, :utc_datetime, presence: true
-    field :updated_at, :utc_datetime, presence: true
     field :start, :time
     field :stop, :time
     field :sidebar_text, :string
     field :show_weather, :boolean
+    timestamps([inserted_at: :created_at, type: :utc_datetime])
 
     belongs_to :location, Location
   end


### PR DESCRIPTION
Ecto.Schema.timestamps automatically fills in 'inserted_at' and 'updated_at' columns. I changed the 'inserted_at' column name to 'created_at' to match the database schema, and the type from default 'naive_datetime' to 'utc_datetime'.