### PR TITLE
chore: gitignore updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ yarn-debug.log*
 
 # Ignore manifest
 /public/manifest.json
+
+# Ignore newly generated sqlite3 db
+/db/development.sqlite3-shm
+/db/development.sqlite3-wal

--- a/server-phoenix/.gitignore
+++ b/server-phoenix/.gitignore
@@ -32,10 +32,6 @@ helios-*.tar
 npm-debug.log
 /assets/node_modules/
 
-# Ignore newly generated sqlite3 db
-db/development.sqlite3-shm
-db/development.sqlite3-wal
-
 # Ignore newly generated test files
 helios_test
 helios_test-shm

--- a/server-phoenix/.gitignore
+++ b/server-phoenix/.gitignore
@@ -36,3 +36,8 @@ npm-debug.log
 db/development.sqlite3-shm
 db/development.sqlite3-wal
 
+# Ignore newly generated test files
+helios_test
+helios_test-shm
+helios_test-wal
+


### PR DESCRIPTION
- Whenever `mix test` done in cmd, these files are generated in server-phoenix:
  - helios_test
  - helios_test-shm
  - helios_test-wal

- Accidentally added sqlite3 db in server-phoenix gitignore in previous merge with master, so removed it and added it to .gitignore
