### PR TITLE
fix: change "after" argument to "created_after"

### DIFF
--- a/app/graphql/types/widget_type.rb
+++ b/app/graphql/types/widget_type.rb
@@ -65,13 +65,13 @@ class Types::NumbersWidget < Types::BaseObject
 
   field :events, Types::EventCollectionType do
     description "MojoTech slack/github events"
-    argument :after, String, required: false
+    argument :created_after, String, required: false
     argument :type, Types::EventSourceType, required: false
   end
 
-  def events(after: nil, type: nil)
+  def events(created_after: nil, type: nil)
     events = Event.all
-    events = events.created_after(after) if after
+    events = events.created_after(created_after) if created_after
     events = events.with_source(type) if type
     events
   end

--- a/app/javascript/components/widgets/numbers/panel.jsx
+++ b/app/javascript/components/widgets/numbers/panel.jsx
@@ -137,7 +137,7 @@ SubscribedEvents.propTypes = {
 const Numbers = ({ startTimer }) => (
   <Query
     query={getEventCounts}
-    variables={{ after: getStartOfWeek() }}
+    variables={{ createdAfter: getStartOfWeek() }}
     onCompleted={startTimer}
     onError={startTimer}
   >

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -4694,7 +4694,7 @@
               "description": "MojoTech slack/github events",
               "args": [
                 {
-                  "name": "after",
+                  "name": "createdAfter",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",

--- a/schema.graphql
+++ b/schema.graphql
@@ -121,7 +121,7 @@ type NumbersWidget implements Widget {
   """
   MojoTech slack/github events
   """
-  events(after: String, type: EventSource): EventCollection!
+  events(createdAfter: String, type: EventSource): EventCollection!
   id: Int!
   locationId: Int!
   name: String!

--- a/server-phoenix/lib/helios_web/schema/types/widget.ex
+++ b/server-phoenix/lib/helios_web/schema/types/widget.ex
@@ -100,7 +100,7 @@ defmodule HeliosWeb.Schema.Types.Widget do
 
     field :events, :event_collection do
       description("MojoTech slack/github events")
-      arg(:after, :string)
+      arg(:created_after, :string)
       arg(:type, :event_source)
       resolve(&EventCollection.events/3)
     end


### PR DESCRIPTION
An error was being thrown in the events widget because the frontend and rails side were still using `after` as an argument (to query events) instead of `createdAfter`.