### PR TITLE
fix: change tweet's created_at format from string to datetime

### DIFF
--- a/server-phoenix/lib/helios_web/clients/tweet.ex
+++ b/server-phoenix/lib/helios_web/clients/tweet.ex
@@ -1,4 +1,6 @@
 defmodule HeliosWeb.Clients.Tweet do
+  use Timex
+
   defstruct [:text, :media, :interactions, :status, :user, :created_at]
 
   defmodule InteractionQuery do
@@ -20,8 +22,13 @@ defmodule HeliosWeb.Clients.Tweet do
       interactions: interactions(tweet),
       status: status(tweet),
       user: user(tweet),
-      created_at: tweet.created_at
+      created_at: created_at(tweet)
     }
+  end
+
+  def created_at(t) do
+    t.created_at
+    |> Timex.parse!("%a %b %d %T %z %Y", :strftime)
   end
 
   def attributes(t) do

--- a/server-phoenix/test/helios_web/clients/tweet_test.exs
+++ b/server-phoenix/test/helios_web/clients/tweet_test.exs
@@ -216,7 +216,7 @@ defmodule HeliosWeb.Clients.TweetTest do
   test "from_api normal status" do
     assert Tweet.from_api(test_tweet_normal()) ===
              %HeliosWeb.Clients.Tweet{
-               created_at: "Wed Mar 16 16:59:00 +0000 2022",
+               created_at: ~U[2022-03-16 16:59:00Z],
                interactions: %HeliosWeb.Clients.Tweet.InteractionQuery{
                  favorite_count: 0,
                  retweet_count: 0
@@ -235,7 +235,7 @@ defmodule HeliosWeb.Clients.TweetTest do
   test "from_api retweet status" do
     assert Tweet.from_api(test_tweet_retweet()) ===
              %HeliosWeb.Clients.Tweet{
-               created_at: "Fri Mar 18 15:56:28 +0000 2022",
+               created_at: ~U[2022-03-18 15:56:28Z],
                interactions: %HeliosWeb.Clients.Tweet.InteractionQuery{
                  favorite_count: 0,
                  retweet_count: 1


### PR DESCRIPTION
Changes due to tweet object having field `created_at` as type `:datetime` but api response outputs a utc datetime string.