### PR TITLE
Add announcements functionality to Slack controller

### DIFF
--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -16,26 +16,39 @@ Once an account is created the API key can be supplied to the corresponding envi
 
 A Slack App and Bot are necessary to handle different events in Helios.
 
-### Authentication
+### Events
 
-All the keys can be found in the [app](https://api.slack.com/apps)'s _Basic Information_ section (if you are a collaborator) and supplied to the Slack environment variables:
-
-- `SLACK_CLIENT_ID=<Client ID>`
-- `SLACK_API_SECRET=<Client Secret>`
-- `SLACK_VERIFICATION_TOKEN=<Verification Token>`
-
-The _Event Subscriptions_ Request URL should be the URL to the `slack_controller`. It is verified if the controller responds with the `challenge` parameter when a JSON with type `url_verification` is sent.
-
-The _OAuth & Permissions_ Redirect URL should be the URL to the `slack_auth_controller`. This is used to authenticate and install the App on the Slack Workspace. The `SLACK_REDIRECT_URI` environment variable should be the same as this.
-
-### Message Count
-
-The Slack Helios App should be subscribed to all `message` Workspace Events in the _Events Subscriptions_ section. The Bot should be subscribed to all `message` Bot Events in case the Bot was added to a private channel.
+1. [Create a new Slack app](https://api.slack.com/apps) **from scratch** and pick the workspace you want it integrated into.
+   ![](https://i.gyazo.com/f5e006fae710a2fa0ea7385bbaf72b98.png)
+2. Go to "Event Subscriptions", "Enable Events", paste in the "Request URL" (Helios backend URL w/ web_hooks/slack), and wait until it verifies. After this, in "Subscribe to bot events" add the event `message.channels`.
+   ![](https://i.gyazo.com/3a5cf9a32ea4f1c836ff8201de300ebb.png)
+   ![](https://i.gyazo.com/e530872d2f0136724f4978ee49082e7e.png)
+3. Go to "OAuth & Permissions" and click on "Install to Workplace" to generate an OAuth Token.
+   ![](https://i.gyazo.com/478b3b2a86f0210000610e74bafe3907.png)
+4. In Slack click on the channel name at the top where you want to add the bot, go to "Integrations" and then add the app that you just created.
+   ![](https://i.gyazo.com/dab35ad22c7c5cc671164482f955c3a3.png)
+   ![](https://i.gyazo.com/f32e9a1e7345c654f0d407a6c599c1e0.png)
+5. Helios will now listen to any messages that appear in the channels that the bot is added to.
 
 ### Announcements
 
-The Slack Helios Bot should be subscribed to the `app_mention` Bot Event.
-For the bot to send messages back, the _Incoming Webhooks_ App should be installed from the [Slack App Directory](https://mojotech.slack.com/apps). The `Webhook URL` provided by this app should be supplied to the `SLACK_WEBHOOK_URL` environment variable.
+1. **First** follow the instructions in the "Events" section above.
+2. Add the bot to the channels you want it to listen to messages in. This doesn't necessarily have to be the #helios channel, but it makes sense to communicate with the bot in the same channel you'll receive replies in.
+3. Enable "Incoming Webhooks" in your Slack app settings, generate a webhook url for the #helios channel, and then update `SLACK_WEBHOOK_URL` in your .env. This is the channel where you will see the bot's replies whether your announcement was saved or if there was an error in the command you entered.
+
+## Sending an Announcement
+
+### Add an announcement using this format:
+
+`@Helios guests: <message> to <people> from <company> on <publish date and time> in <office location>`
+
+- ### The `<office location>` should be either `Providence` or `Boulder`
+- ### The `<publish date and time>` should look like this:
+  ✅ August 23rd 2019 at 09:00 am
+  - ### Not like this (needs the suffix after the day)
+    ❌ August 23 2019 at 09:00 am
+  - ### Or this (needs the leading zero if hour is a single digit)
+    ❌ August 23rd 2019 at 9:00 am
 
 ## Twitter
 
@@ -46,6 +59,7 @@ You will likely need to [apply for 'Elevated' API access](https://developer.twit
 This will give you access to your "Access Tokens".
 
 Once access is granted, all the keys needed for your environment variables can be found in your App's "Keys and Tokens" page on the [Twitter Developer Portal](https://developer.twitter.com/en/portal/dashboard), named as follows:
+
 - `TWITTER_CONSUMER_KEY=<API Key>`
 - `TWITTER_CONSUMER_SECRET=<API Secret>`
 - `TWITTER_ACCESS_TOKEN=<Authentication Token>`

--- a/app/javascript/components/widget-display.jsx
+++ b/app/javascript/components/widget-display.jsx
@@ -9,6 +9,7 @@ import {
 } from '@messages/message';
 import FullPanel from '@components/full-panel';
 import SidePanel, { getSidePanel } from '@components/side-panel';
+import Guests from '@widgets/guests';
 import Twitter from '@widgets/twitter';
 import Numbers from '@widgets/numbers';
 import Weather from '@widgets/weather';
@@ -28,6 +29,7 @@ export const getWidgetDisplay = gql`
 `;
 
 const widgetElements = {
+  Guests,
   Weather,
   Twitter,
   Numbers,
@@ -47,6 +49,7 @@ export const WidgetDisplay = ({
 }) => {
   const { byIdOrFirst: current, enabled: enabledWidgets } = location.widgets;
   const WidgetElement = widgetElements[current.name].Panel;
+
   return (
     <Wrapper
       onKeyDown={keyToWidgetAction}

--- a/app/javascript/components/widgets/guests/panel.jsx
+++ b/app/javascript/components/widgets/guests/panel.jsx
@@ -6,7 +6,11 @@ import gql from 'graphql-tag';
 import styled from 'styled-components';
 import { parseDate, isInFutureToday } from '@lib/datetime';
 import { colors, weights, fontSizes, spacing } from '@lib/theme';
-import { LoadingMessage, DisconnectedMessage } from '@messages/message';
+import {
+  LoadingMessage,
+  DisconnectedMessage,
+  NoAnnouncementsMessage,
+} from '@messages/message';
 
 const subscribeAnnouncementPublished = gql`
   subscription onAnnouncementPublished {
@@ -117,8 +121,12 @@ const Guests = ({ startTimer, cityName }) => (
         return <DisconnectedMessage />;
       }
 
-      if (loading || data.location.dayAnnouncements.length === 0) {
+      if (loading) {
         return <LoadingMessage />;
+      }
+
+      if (data.location.dayAnnouncements.length === 0) {
+        return <NoAnnouncementsMessage />;
       }
 
       return (

--- a/app/javascript/components/widgets/guests/panel.jsx
+++ b/app/javascript/components/widgets/guests/panel.jsx
@@ -15,7 +15,7 @@ const subscribeAnnouncementPublished = gql`
       people
       company
       publishOn
-      id
+      announcementId
     }
   }
 `;
@@ -28,6 +28,7 @@ const getLocationAnnouncements = gql`
         people
         company
         publishOn
+        announcementId
       }
     }
   }
@@ -77,7 +78,7 @@ Announcement.propTypes = {
     people: PropTypes.string.isRequired,
     company: PropTypes.string.isRequired,
     publishOn: PropTypes.string.isRequired,
-    id: PropTypes.string.isRequired,
+    announcementId: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/app/javascript/components/widgets/guests/panel.jsx
+++ b/app/javascript/components/widgets/guests/panel.jsx
@@ -90,8 +90,7 @@ class SubscribedAnnouncements extends React.Component {
   render() {
     const { dayAnnouncements } = this.props;
     const announcement = sortBy(prop('publishOn'), dayAnnouncements)[0];
-
-    return <Announcement anouncement={announcement} />;
+    return <Announcement announcement={announcement} />;
   }
 }
 SubscribedAnnouncements.propTypes = {
@@ -101,14 +100,18 @@ SubscribedAnnouncements.propTypes = {
       people: PropTypes.string.isRequired,
       company: PropTypes.string.isRequired,
       publishOn: PropTypes.string.isRequired,
-      id: PropTypes.string.isRequired,
+      announcementId: PropTypes.string.isRequired,
     }),
   ).isRequired,
   subscribeToPublishedAnnouncements: PropTypes.func.isRequired,
 };
 
-const Guests = ({ cityName }) => (
-  <Query query={getLocationAnnouncements} variables={{ cityName }}>
+const Guests = ({ startTimer, cityName }) => (
+  <Query
+    query={getLocationAnnouncements}
+    variables={{ cityName }}
+    onCompleted={startTimer}
+  >
     {({ loading, error, data, subscribeToMore }) => {
       if (error) {
         return <DisconnectedMessage />;
@@ -159,6 +162,7 @@ const Guests = ({ cityName }) => (
 );
 
 Guests.propTypes = {
+  startTimer: PropTypes.func.isRequired,
   cityName: PropTypes.string.isRequired,
 };
 export default Guests;

--- a/app/javascript/components/widgets/messages/message.jsx
+++ b/app/javascript/components/widgets/messages/message.jsx
@@ -9,6 +9,9 @@ export const LoadingMessage = () => <Message message="Loading..." />;
 export const DisconnectedMessage = () => (
   <Message message="Looks like we're disconnected" />
 );
+export const NoAnnouncementsMessage = () => (
+  <Message message="No announcements today" />
+);
 export const WeatherLoadingMessage = () => <WeatherMessage />;
 export const WeatherDisconnectedMessage = () => <WeatherMessage />;
 export const WidgetDisabledMessage = () => (

--- a/app/javascript/components/widgets/numbers/panel.jsx
+++ b/app/javascript/components/widgets/numbers/panel.jsx
@@ -128,10 +128,16 @@ class SubscribedEvents extends React.Component {
   }
 }
 SubscribedEvents.propTypes = {
-  githubPull: PropTypes.number.isRequired,
-  githubCommit: PropTypes.number.isRequired,
-  slackMessage: PropTypes.number.isRequired,
+  githubPull: PropTypes.number,
+  githubCommit: PropTypes.number,
+  slackMessage: PropTypes.number,
   subscribeToPublishedEvents: PropTypes.func.isRequired,
+};
+
+SubscribedEvents.defaultProps = {
+  githubPull: 0,
+  githubCommit: 0,
+  slackMessage: 0,
 };
 
 const Numbers = ({ startTimer }) => (

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,7 +34,7 @@ Location.all.each do |location|
     name: "Guests",
     location: location
   ) do |r|
-    r.enabled = false
+    r.enabled = true
     r.duration_seconds = 20
     r.position = 0
     r.sidebar_text = 'Guests'

--- a/server-phoenix/lib/helios/announcement.ex
+++ b/server-phoenix/lib/helios/announcement.ex
@@ -14,14 +14,14 @@ defmodule Helios.Announcement do
 
   @primary_key {:id, :id, autogenerate: true}
   schema "announcements" do
-    field :publish_on, :utc_datetime
-    field :message, :string
-    field :people, :string
-    field :company, :string
-    field :announcement_id, :string
+    field(:publish_on, :utc_datetime)
+    field(:message, :string)
+    field(:people, :string)
+    field(:company, :string)
+    field(:announcement_id, :string)
     timestamps(inserted_at: :created_at, type: :utc_datetime)
 
-    belongs_to :location, Location
+    belongs_to(:location, Location)
   end
 
   def changeset(announcement, attrs \\ %{}) do
@@ -35,10 +35,8 @@ defmodule Helios.Announcement do
   end
 
   def happen_today(query, time_zone) do
-    {:ok, today} = DateTime.now(time_zone)
+    today = DateTime.now!(time_zone) |> DateTime.shift_zone!("Etc/UTC")
     tomorrow = DateTime.add(today, 86400)
-
-    from q in query,
-      where: q.publish_on > fragment("?", ^today) and q.publish_on < fragment("?", ^tomorrow)
+    from(q in query, where: q.publish_on >= ^today and q.publish_on <= ^tomorrow)
   end
 end

--- a/server-phoenix/lib/helios_web/controllers/web_hooks/slack_controller.ex
+++ b/server-phoenix/lib/helios_web/controllers/web_hooks/slack_controller.ex
@@ -1,33 +1,175 @@
 defmodule HeliosWeb.WebHooks.SlackController do
   use HeliosWeb, :controller
-  alias Helios.{Repo, Event}
+  alias Helios.{Repo, Event, Location, Announcement}
 
   def handle(conn, params) do
-    if params["type"] == "url_verification" do
-      send_resp(conn, 200, params["challenge"])
-    else
-      event = params["event"]
+    case params["type"] do
+      "url_verification" ->
+        send_resp(conn, 200, params["challenge"])
 
-      unless Event
-             |> Event.slack_messages()
-             |> Event.with_external_id(event["event_ts"])
-             |> Repo.exists?() do
-        Repo.insert!(%Event{
-          source: :slack_message,
-          external_id: event["event_ts"]
-        })
-        |> publish
-      end
+      "event_callback" ->
+        event = params["event"]
 
-      send_resp(conn, 200, "OK")
+        unless allow_event?(event) do
+          send_resp(conn, 200, "Skipping disallowed event")
+        else
+          case slack_event(event) do
+            {:ok, _} ->
+              send_resp(conn, 200, "OK")
+
+            {:error, message} ->
+              send_slack_message(event["user"], message)
+              send_resp(conn, 200, "OK")
+          end
+        end
+
+      _ ->
+        send_resp(conn, 200, "Invalid request type")
     end
   end
 
-  defp publish(event) do
+  defp allow_event?(event) do
+    subtypes =
+      ~w(file_comment file_mention file_share me_message message_replied thread_broadcast)
+
+    (event["type"] == "message" || event["type"] == "app_mention") &&
+      (event["subtype"] == nil || Enum.member?(subtypes, event["subtype"]))
+  end
+
+  defp slack_event(event) do
+    case event["type"] do
+      "message" ->
+        unless Event
+               |> Event.slack_messages()
+               |> Event.with_external_id(event["event_ts"])
+               |> Repo.exists?() or message_has_mention?(event) do
+          Repo.insert!(%Event{
+            source: :slack_message,
+            external_id: event["event_ts"]
+          })
+          |> publish_event
+        else
+          {:ok, "Event Skipped"}
+        end
+
+      "app_mention" ->
+        case parse_announcement(event) do
+          {:ok, announcement} ->
+            Repo.insert!(struct(Announcement, announcement)) |> publish_announcement(event)
+
+          {:error, message} ->
+            {:error, message}
+        end
+    end
+  end
+
+  defp message_has_mention?(event) do
+    Regex.match?(~r/(?<bot_id>^<\S+>) (?<content>.*)$/, event["text"])
+  end
+
+  defp publish_event(event) do
     Absinthe.Subscription.publish(
       HeliosWeb.Endpoint,
       event,
       event_published: "all"
     )
+
+    {:ok, "Event Published"}
+  end
+
+  defp publish_announcement(announcement, event) do
+    Absinthe.Subscription.publish(
+      HeliosWeb.Endpoint,
+      announcement,
+      announcement_published: "new"
+    )
+
+    send_slack_message(event["user"], "The announcement was saved :rocket:")
+    {:ok, "Announcement Published"}
+  end
+
+  defp parse_announcement(event) do
+    with command =
+           Regex.named_captures(
+             ~r/(?<bot_id>^<\S+>) (?<type>\S+) (?<content>.*)$/,
+             event["text"]
+           ),
+         {:valid_command, true} <- {:valid_command, Enum.count(command) === 3},
+         {:valid_type, true} <- {:valid_type, Map.fetch!(command, "type") === "guests:"},
+         {:announcement_parse, {:ok, announcement}} <-
+           {:announcement_parse, handle_guests_command(command["content"])},
+         announcement = Map.put(announcement, :announcement_id, event["event_ts"]) do
+      {:ok, announcement}
+    else
+      {_, false} ->
+        {:error,
+         "I couldn't understand that...\n\nMake sure your command follows this format: `guests: <message> to <people> from <company> on <publish date and time> in <office location>`.\n\n`<publish date and time>` should look like this, `August 23rd 2019 at 09:00 am`, with the full month name, suffix after day, and leading 0 if the hour is a single digit.\n\n`<office location>` should be `Providence` or `Boulder`."}
+
+      {:announcement_parse, {:error, message}} ->
+        {:error, message}
+    end
+  end
+
+  defp send_slack_message(user, message) do
+    HTTPoison.post!(
+      System.get_env("SLACK_WEBHOOK_URL"),
+      %{text: "<@#{user}> #{message}"} |> Jason.encode!(),
+      [{"Content-type", "application/json"}],
+      []
+    )
+  end
+
+  defp handle_guests_command(content) do
+    fields = ~w(message people company publish_on location_name)a
+
+    with content = String.split(content, ~r/ to | from | on | in /, trim: true),
+         {:content_count, true} <- {:content_count, Enum.count(content) === 5},
+         announcement = Enum.zip(fields, content) |> Enum.into(%{}),
+         {:location_query, location} when location !== nil <-
+           {:location_query, Repo.get_by(Location, city_name: announcement.location_name)},
+         {:dt_parse, {:ok, publish_on}} <-
+           {:dt_parse,
+            parse_publish_on(
+              announcement.publish_on,
+              location.time_zone
+            )} do
+      {:ok,
+       announcement
+       |> Map.put(
+         :location,
+         location
+       )
+       |> Map.replace(
+         :publish_on,
+         publish_on
+       )}
+    else
+      {:content_count, false} ->
+        {:error,
+         "I couldn't understand that...\n\nMake sure your command follows this format: `guests: <message> to <people> from <company> on <publish date and time> in <office location>`.\n\n`<publish date and time>` should look like this, `August 23rd 2019 at 09:00 am`, with the full month name, suffix after day, and leading 0 if the hour is a single digit.\n\n`<office location>` should be `Providence` or `Boulder`."}
+
+      {:location_query, nil} ->
+        {:error,
+         "I couldn't understand that...\n\nMake sure the office location is either `Providence` or `Boulder`."}
+
+      {:dt_parse, {:error, _message}} ->
+        {:error,
+         "I couldn't understand that...\n\nThe date and time should look like this, `August 23rd 2019 at 09:00 am`, with the full month name, suffix after day, and leading 0 if the hour is a single digit."}
+    end
+  end
+
+  defp parse_publish_on(dt, tz) do
+    {:ok,
+     remove_ordinal_suffix_publish_on(dt)
+     |> Timex.parse!("%B %e %Y at %I:%M %p", :strftime)
+     |> DateTime.from_naive!(tz)
+     |> DateTime.shift_zone!("Etc/UTC")}
+  rescue
+    e in Timex.Parse.ParseError ->
+      {:error, e.message}
+  end
+
+  def remove_ordinal_suffix_publish_on(dt) do
+    String.replace(dt, ~r/([0-9])(st|nd|rd|th)/, "\\1")
   end
 end

--- a/server-phoenix/lib/helios_web/schema/types/sub.ex
+++ b/server-phoenix/lib/helios_web/schema/types/sub.ex
@@ -63,7 +63,11 @@ defmodule HeliosWeb.Schema.Types.Sub do
 
     field(:announcement_published, non_null(:announcement),
       description: "An announcement was published"
-    )
+    ) do
+      config(fn _args, _resolution ->
+        {:ok, topic: "new"}
+      end)
+    end
 
     field(:deployment_sha, non_null(:string), description: "Updated SHA value") do
       config(fn _args, _resolution ->

--- a/server-phoenix/priv/repo/seeds.exs
+++ b/server-phoenix/priv/repo/seeds.exs
@@ -41,7 +41,7 @@ EctoHelpers.find_or_initialize_by(Location, [city_name: "San Diego"], %Location{
 Repo.all(Location)
 |> Enum.each(fn location ->
   EctoHelpers.find_or_initialize_by(Widget, [name: "Guests", location_id: location.id], %Widget{
-    enabled: false,
+    enabled: true,
     duration_seconds: 20,
     position: 0,
     sidebar_text: "Guests",

--- a/server-phoenix/test/helios_web/controllers/web_hooks/slack_controller_test.exs
+++ b/server-phoenix/test/helios_web/controllers/web_hooks/slack_controller_test.exs
@@ -1,0 +1,14 @@
+defmodule HeliosWeb.WebHooks.SlackControllerTest do
+  use ExUnit.Case
+  alias HeliosWeb.WebHooks.SlackController
+
+  test "Remove 'rd' ordinal suffix from day" do
+    assert SlackController.remove_ordinal_suffix_publish_on("May 23rd 2019 at 11:00 am") ===
+             "May 23 2019 at 11:00 am"
+  end
+
+  test "Remove 'th' ordinal suffix from day" do
+    assert SlackController.remove_ordinal_suffix_publish_on("August 5th 2019 at 09:00 am") ===
+             "August 5 2019 at 09:00 am"
+  end
+end


### PR DESCRIPTION
## Setup Instructions
1. **First** follow the instructions here #354 to set up "Event Subscriptions".
2. Add the bot to the channels you want it to listen to messages in. This doesn't necessarily have to be the #helios channel, but it makes sense to communicate with the bot in the same channel you'll receive replies in.
3. Enable "Incoming Webhooks" in your Slack app settings, generate a webhook url for the #helios channel, and then update  `SLACK_WEBHOOK_URL` in your .env. This is the channel where you will see the bot's replies whether your announcement was saved or if there was an error in the command you entered.

## Sending an Announcement
### Add an announcement using this format:
`@Helios guests: <message> to <people> from <company> on <publish date and time> in <office location>`

- ### The `<office location>` should be either `Providence` or `Boulder`
- ### The `<publish date and time>` should look like this: 
✅ August 23rd 2019 at 09:00 am
  - ### Not like this (needs the suffix after the day)
❌ August 23 2019 at 09:00 am
  - ### Or this (needs the leading zero if hour is a single digit)
❌ August 23rd 2019 at 9:00 am