### PR TITLE
Fix weather client caching a bad response

### DIFF
--- a/app/javascript/components/app.jsx
+++ b/app/javascript/components/app.jsx
@@ -52,11 +52,11 @@ const client = new ApolloClient({
   defaultOptions: {
     query: {
       fetchPolicy: 'network-only',
-      errorPolicy: 'all',
+      errorPolicy: 'none',
     },
     watchQuery: {
       fetchPolicy: 'network-only',
-      errorPolicy: 'all',
+      errorPolicy: 'none',
     },
   },
 });

--- a/server-phoenix/lib/helios_web/schema/resolvers/location.ex
+++ b/server-phoenix/lib/helios_web/schema/resolvers/location.ex
@@ -12,7 +12,7 @@ defmodule HeliosWeb.Schema.Resolvers.Location do
   end
 
   def weather(parent, _args, _info) do
-    {:ok, WeatherClient.forecast(parent)}
+    WeatherClient.forecast(parent)
   end
 
   def traffic_cams(parent, _args, _info) do

--- a/server-phoenix/lib/helios_web/schema/resolvers/widget.ex
+++ b/server-phoenix/lib/helios_web/schema/resolvers/widget.ex
@@ -7,8 +7,8 @@ defmodule HeliosWeb.Schema.Resolvers.Widget do
     {:ok, []}
   end
 
-  def weather(%Widget{location: location}, _args, _info) do
-    {:ok, WeatherClient.forecast(location)}
+  def weather(parent, _args, _info) do
+    WeatherClient.forecast(parent)
   end
 
   def tweets(_parent, _args, _info) do


### PR DESCRIPTION
The weather client was caching a bad response if there was an error with OpenWeatherAPI. 
- Weather will now resolve to a GraphQL error if the response is bad (ex: API key is invalid)
- I also changed ApolloClient's errorPolicy to `none` so the `error` parameter in `useQuery` can be populated with errors. Before it was set to `all`, which renders partial data even if there's an error.
See here for more information: https://www.apollographql.com/docs/react/v2/data/queries/#inspecting-error-states 