### PR TITLE
fix: incorrect backend env variable

### DIFF
--- a/server-phoenix/lib/mix/tasks/simulate.ex
+++ b/server-phoenix/lib/mix/tasks/simulate.ex
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Simulate do
 
       try do
         HTTPoison.post!(
-          "#{System.get_env("PHOENIX_BACKEND_URI")}/web_hooks/publish",
+          "#{System.get_env("BACKEND_URL")}/web_hooks/publish",
           event |> Map.from_struct() |> Map.delete(:__meta__) |> Jason.encode!(),
           [{"Content-type", "application/json"}],
           []

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -119,7 +119,7 @@ module.exports = {
           '/events',
           '/web_hooks',
         ],
-        target: process.env.BACKEND_URI,
+        target: process.env.BACKEND_URL,
       },
     ],
   },


### PR DESCRIPTION
I forgot to update the backend url to `BACKEND_URL` in 2 spots.