### PR TITLE
Fix for #182249098 bug, involving PVD showing night time during the day

### DIFF
--- a/app/javascript/components/widgets/weather/sunrise-sunset.jsx
+++ b/app/javascript/components/widgets/weather/sunrise-sunset.jsx
@@ -90,8 +90,8 @@ export const SunriseSunset = ({ location, weather }) => {
     );
   }
 
-  const beginTime = takeLast(1, beforeNow)[0];
-  const endTime = take(1, afterNow)[0];
+  const beginTime = take(1, afterNow)[0];
+  const endTime = takeLast(1, beforeNow)[0];
 
   const capitalize = replace(/^./, toUpper());
 


### PR DESCRIPTION
beginTime and endTime had swapped values which caused the sunset and sunrise times and sides to be flipped as well as the moon/sun to be opposite what it should be. Example below.
Before:
<img width="446" alt="Screen Shot 2022-05-24 at 10 58 07 AM" src="https://user-images.githubusercontent.com/46508152/170091340-dacd48a1-b09a-432c-94d6-1ddf9379fd63.png">
After:
<img width="456" alt="Screen Shot 2022-05-24 at 10 57 41 AM" src="https://user-images.githubusercontent.com/46508152/170091350-b3d08f7e-0634-45aa-bc4c-93197bac6791.png">

