### PR TITLE
chore: bump to erlang 24.3.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 ruby 2.6.9
-erlang 24.1.7
+erlang 24.3.3
 elixir 1.13.3
 nodejs 16.14.0
 yarn 1.22.17


### PR DESCRIPTION
ubuntu has a compilation compatibilty issue with >=24.1.7 and <24.3.3