### PR TITLE
Make Empty and Error pages periodically poll the server to refresh data

### DIFF
--- a/app/javascript/components/widget-controller.jsx
+++ b/app/javascript/components/widget-controller.jsx
@@ -56,12 +56,17 @@ export const WidgetController = ({ client, cityName }) => {
       variables={{ id: newWidgetId, cityName }}
       fetchPolicy={fetchPolicy}
     >
-      {({ loading, error, data }) => {
+      {({ loading, error, data, refetch }) => {
         if (loading) {
           return <LoadingDisplay cityName={cityName} loading={loading} />;
         }
 
         if (error) {
+          setTimeout(async () => {
+            await client.resetStore();
+            await refetch();
+          }, 5000);
+
           // eslint-disable-next-line
           console.error(error);
           return <DisconnectedDisplay cityName={cityName} error={error} />;


### PR DESCRIPTION
Page no longer needs to be refreshed if there was an error communicating to the DB, it will try again to refetch the data on error. This also means the webpage can be loaded before the DB server is up, and discover the widgets once DB is alive. Page can also now be opened with all widgets disabled, as enabling a widget after the fact will now work as well. 

Though note that disabling an *active* widget will still require a page refresh.

DB re-check timeout is 5 seconds. (i.e., if there is an error connecting to the DB, Apollo/React will try again every two seconds).