### PR TITLE
GraphQL + Frontend error handling

### DIFF
--- a/app/javascript/components/bathroom.jsx
+++ b/app/javascript/components/bathroom.jsx
@@ -23,6 +23,8 @@ export const Bathroom = ({ loading, error, location }) => {
     return <LoadingMessage />;
   }
   if (error) {
+    // eslint-disable-next-line
+    console.error(error);
     return <ErrorMessage />;
   }
 

--- a/app/javascript/components/date.jsx
+++ b/app/javascript/components/date.jsx
@@ -72,6 +72,8 @@ export class Date extends React.Component {
     }
 
     if (error) {
+      // eslint-disable-next-line
+      console.error(error);
       return <ErrorMessage />;
     }
 

--- a/app/javascript/components/errorLink.test.jsx
+++ b/app/javascript/components/errorLink.test.jsx
@@ -1,0 +1,46 @@
+/* eslint-disable graphql/template-strings */
+import { execute, from } from 'apollo-link';
+import gql from 'graphql-tag';
+import { createHttpLink } from 'apollo-link-http';
+import waitFor from 'wait-for-observables';
+import { errorLink } from './app';
+
+const { log } = console;
+
+// Save original console.log function
+beforeEach(() => {
+  // eslint-disable-next-line no-console
+  console.log = jest.fn();
+});
+
+// Restore original console.log after all tests
+afterAll(() => {
+  // eslint-disable-next-line no-console
+  console.log = log;
+});
+
+const MockQuery = gql`
+  query {
+    foo
+  }
+`;
+
+describe('sends an invalid query to GQL and sees if the Apollo errorLink is able to handle it', () => {
+  test('console.log should have a message from errorLink after the resolver blows up', async () => {
+    expect.assertions(1);
+    const mockLink = createHttpLink({
+      uri: 'http://localhost:4000/graphql',
+      credentials: 'include',
+    });
+
+    await waitFor(execute(from([errorLink, mockLink]), { query: MockQuery }));
+    const errors = [
+      '[GraphQL Error]: Message: Cannot query field "foo" on type "RootQueryType"., Location: [object Object], Path: undefined, Operation: [object Object], Response: [object Object]',
+      '[Network Error]: FetchError: request to http://localhost:4000/graphql failed, reason: connect ECONNREFUSED 127.0.0.1:4000',
+    ];
+    expect(errors).toContain(
+      // eslint-disable-next-line no-console
+      console.log.mock.calls[0][0],
+    );
+  });
+});

--- a/app/javascript/components/time-hero.jsx
+++ b/app/javascript/components/time-hero.jsx
@@ -16,6 +16,8 @@ export const TimeHero = ({ loading, error, location }) => {
     return <LoadingMessage />;
   }
   if (error) {
+    // eslint-disable-next-line
+    console.error(error);
     return <ErrorMessage />;
   }
 

--- a/app/javascript/components/widgets/guests/panel.jsx
+++ b/app/javascript/components/widgets/guests/panel.jsx
@@ -110,6 +110,8 @@ const Guests = ({ cityName }) => (
   <Query query={getLocationAnnouncements} variables={{ cityName }}>
     {({ loading, error, data, subscribeToMore }) => {
       if (error) {
+        // eslint-disable-next-line
+        console.error(error);
         return <DisconnectedMessage />;
       }
 

--- a/app/javascript/components/widgets/numbers/panel.jsx
+++ b/app/javascript/components/widgets/numbers/panel.jsx
@@ -147,6 +147,8 @@ const Numbers = ({ startTimer }) => (
       }
 
       if (error) {
+        // eslint-disable-next-line
+        console.error(error);
         return <DisconnectedMessage />;
       }
 

--- a/app/javascript/components/widgets/twitter/panel.jsx
+++ b/app/javascript/components/widgets/twitter/panel.jsx
@@ -115,6 +115,8 @@ const TwitterController = ({ startTimer }) => (
       }
 
       if (error) {
+        // eslint-disable-next-line
+        console.error(error);
         return <DisconnectedMessage />;
       }
 

--- a/app/javascript/components/wifi.jsx
+++ b/app/javascript/components/wifi.jsx
@@ -35,6 +35,8 @@ export const Wifi = ({ loading, error, location }) => {
     return <LoadingMessage />;
   }
   if (error) {
+    // eslint-disable-next-line
+    console.error(error);
     return <ErrorMessage />;
   }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "apollo-client": "^2.6.2",
     "apollo-link": "^1.2.2",
     "apollo-link-context": "^1.0.20",
+    "apollo-link-error": "1.1.13",
     "apollo-link-http": "^1.5.4",
     "apollo-utilities": "^1.3.2",
     "core-js": "3.1.3",
@@ -29,6 +30,7 @@
     "graphql-tag": "^2.9.2",
     "hoist-non-react-statics": "^3.0.1",
     "html-entities": "^1.2.1",
+    "isomorphic-fetch": "^3.0.0",
     "js-cookie": "^3.0.1",
     "matter-js": "^0.14.2",
     "numeral": "^2.0.6",
@@ -45,7 +47,8 @@
     "regenerator-runtime": "^0.13.7",
     "resurrect-js": "^1.0.1",
     "styled-components": "^4.0.0",
-    "styled-normalize": "^4.0.0"
+    "styled-normalize": "^4.0.0",
+    "wait-for-observables": "^1.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2424,6 +2424,15 @@ apollo-link-context@^1.0.20:
     apollo-link "^1.2.14"
     tslib "^1.9.3"
 
+apollo-link-error@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/apollo-link-error/-/apollo-link-error-1.1.13.tgz#c1a1bb876ffe380802c8df0506a32c33aad284cd"
+  integrity sha512-jAZOOahJU6bwSqb2ZyskEK1XdgUY9nkmeclCrW7Gddh1uasHVqmoYc4CKdb0/H0Y1J9lvaXKle2Wsw/Zx1AyUg==
+  dependencies:
+    apollo-link "^1.2.14"
+    apollo-link-http-common "^0.2.16"
+    tslib "^1.9.3"
+
 apollo-link-http-common@^0.2.13:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.13.tgz#c688f6baaffdc7b269b2db7ae89dae7c58b5b350"
@@ -2431,6 +2440,15 @@ apollo-link-http-common@^0.2.13:
   dependencies:
     apollo-link "^1.2.11"
     ts-invariant "^0.3.2"
+    tslib "^1.9.3"
+
+apollo-link-http-common@^0.2.16:
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.16.tgz#756749dafc732792c8ca0923f9a40564b7c59ecc"
+  integrity sha512-2tIhOIrnaF4UbQHf7kjeQA/EmSorB7+HyJIIrUjJOKBgnXwuexi8aMecRlqTIDWcyVXCeqLhUnztMa6bOH/jTg==
+  dependencies:
+    apollo-link "^1.2.14"
+    ts-invariant "^0.4.0"
     tslib "^1.9.3"
 
 apollo-link-http@^1.5.4:
@@ -6994,6 +7012,14 @@ isobject@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-4.0.0.tgz#3f1c9155e73b192022a80819bacd0343711697b0"
   integrity sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==
+
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
 
 isomorphic-ws@4.0.1:
   version "4.0.1"
@@ -12052,7 +12078,7 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.2.tgz#be8e4bfce5d00f0f58e0666a82260c34a57af552"
   integrity sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA==
 
-tslib@^1.10.0:
+tslib@^1.10.0, tslib@^1.8.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -12430,6 +12456,13 @@ w3c-xmlserializer@^2.0.0:
   dependencies:
     xml-name-validator "^3.0.0"
 
+wait-for-observables@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/wait-for-observables/-/wait-for-observables-1.0.3.tgz#3b3def5f556b4b6411f608899746dd39cfdcc3f3"
+  integrity sha1-Oz3vX1VrS2QR9giJl0bdOc/cw/M=
+  dependencies:
+    tslib "^1.8.0"
+
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
@@ -12606,6 +12639,11 @@ whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Added console.error statements for wherever errors were being handled in the front end before either `<ErrorMessage/>` or `<DisconnectedMessage/>` was being returned. 

Also added the apollo-link-error dependency for GraphQL error handling (both GraphQL errors and Network errors). Documentation can be found here: https://www.apollographql.com/docs/react/api/link/apollo-link-error/