### PR TITLE
chore: Added FRONTEND_URL env var to Cypress and webpack

### DIFF
--- a/cypress/integration/smoke-test-main-page.spec.js
+++ b/cypress/integration/smoke-test-main-page.spec.js
@@ -2,7 +2,7 @@
   describe('main page, smoke test', () => {
     beforeEach(() => {
       cy.fixViewport();
-      cy.visit(`http://localhost:3000/${location}`);
+      cy.visit(`${Cypress.env('FRONTEND_URL')}/${location}`);
       cy.waitForInitialContent();
     });
 

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -11,6 +11,7 @@
 
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
+require('dotenv').config();
 
 /**
  * @type {Cypress.PluginConfig}
@@ -19,4 +20,6 @@
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
-}
+  // eslint-disable-next-line no-param-reassign
+  return { ...config, env: { ...process.env, ...config.env } };
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,10 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 require('dotenv').config({ path: path.resolve(__dirname, '.env') });
 
+const frontendUrl = new URL(
+  process.env.FRONTEND_URL || 'http://localhost:3000',
+);
+
 module.exports = {
   mode: 'development',
   output: {
@@ -85,13 +89,13 @@ module.exports = {
     quiet: false,
     disableHostCheck: true,
     host: '0.0.0.0',
-    port: 3000,
+    port: frontendUrl.port,
     https: false,
     hot: false,
     contentBase: path.resolve(__dirname, './server-phoenix/priv/static'),
     inline: true,
     useLocalIp: false,
-    public: 'localhost:3000',
+    public: frontendUrl.host,
     publicPath: '/',
     historyApiFallback: {
       disableDotRule: true,
@@ -143,7 +147,7 @@ module.exports = {
           {
             loader: 'file-loader',
             options: {
-              name: function(file) {
+              name(file) {
                 if (file.includes('app/javascript')) {
                   return 'media/[path][name]-[hash].[ext]';
                 }


### PR DESCRIPTION
This is done so that when we change the FRONTEND_URL in .env, Cypress runs its tests with the new url, and it is also changed for accessing locally (e.g. localhost:5000 to localhost:3000)