### PR TITLE
feat: add graphql high-score query

### DIFF
--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -1044,6 +1044,41 @@
           "possibleTypes": null
         },
         {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "count",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "sourceAuthor",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "AuthorContribution",
+          "possibleTypes": null
+        },
+        {
           "description": "The `Boolean` scalar type represents `true` or `false`.",
           "enumValues": null,
           "fields": null,
@@ -1130,6 +1165,22 @@
                   "ofType": null
                 }
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "sourceAuthor",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
             }
           ],
           "inputFields": null,
@@ -1159,6 +1210,33 @@
                     "name": "Event",
                     "ofType": null
                   }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "top",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "byAuthor",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AuthorContribution",
+                  "ofType": null
                 }
               }
             },

--- a/schema.graphql
+++ b/schema.graphql
@@ -26,15 +26,22 @@ type Announcement {
     publishOn: DateTime!
 }
 
+type AuthorContribution {
+    count: Int
+    sourceAuthor: String
+}
+
 type Event {
     externalId: String!
     id: ID!
     insertedAt: DateTime!
     source: EventSource!
+    sourceAuthor: String!
 }
 
 type EventCollection {
     all: [Event]!
+    byAuthor(top: Int): [AuthorContribution]
     count: EventCount!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,369 +1,312 @@
+# This file was generated based on "schema.json". Do not edit manually.
+
+schema {
+    query: RootQueryType
+    subscription: RootSubscriptionType
+}
+
+"A single tab or panel of Helios"
+interface Widget {
+    durationSeconds: Int!
+    id: Int!
+    locationId: String!
+    name: String!
+    position: Int!
+    showWeather: Boolean
+    sidebarText: String
+}
+
 type Announcement {
-  announcementId: String!
-  company: String!
-  id: ID!
-  locationId: Int!
-  message: String!
-  people: String!
-  publishOn: UTCDateTime!
-}
-
-scalar DateTime
-
-type Employee {
-  displayName: String!
-  id: ID!
-  isPhotoUploaded: String!
-  photoUrl: String!
-}
-
-type EmployeeEventCollection {
-  anniversaryEmployees: [Employee!]!
-  birthdayEmployees: [Employee!]!
-  timeOffEmployees: [Employee!]!
+    announcementId: String!
+    company: String!
+    id: ID!
+    locationId: String!
+    message: String!
+    people: String!
+    publishOn: DateTime!
 }
 
 type Event {
-  insertedAt: DateTime!
-  externalId: String!
-  id: ID!
-  source: EventSource!
+    externalId: String!
+    id: ID!
+    insertedAt: DateTime!
+    source: EventSource!
 }
 
 type EventCollection {
-  all: [Event!]!
-  count: EventCount!
+    all: [Event]!
+    count: EventCount!
 }
 
 type EventCount {
-  githubCommit: Int!
-  githubPull: Int!
-  slackMessage: Int!
-}
-
-enum EventSource {
-  """
-  Github commit
-  """
-  githubCommit
-
-  """
-  Github pull request
-  """
-  githubPull
-
-  """
-  Slack message
-  """
-  slackMessage
+    githubCommit: Int
+    githubPull: Int
+    slackMessage: Int
 }
 
 type EventsWidget implements Widget {
-  durationSeconds: Int!
-  id: Int!
-  locationId: Int!
-  name: String!
-  position: Int!
-  showWeather: Boolean
-  sidebarText: String
+    durationSeconds: Int!
+    id: Int!
+    locationId: String!
+    name: String!
+    position: Int!
+    showWeather: Boolean
+    sidebarText: String
 }
 
 type GuestsWidget implements Widget {
-  """
-  MojoTech announcements today
-  """
-  dayAnnouncements: [Announcement!]!
-  durationSeconds: Int!
-  id: Int!
-  locationId: Int!
-  name: String!
-  position: Int!
-  showWeather: Boolean
-  sidebarText: String
+    "MojoTech announcements today"
+    dayAnnouncements: [Announcement]!
+    durationSeconds: Int!
+    id: Int!
+    locationId: String!
+    name: String!
+    position: Int!
+    showWeather: Boolean
+    sidebarText: String
 }
 
-scalar IconIdToName
+type Interaction {
+    favoriteCount: Int!
+    retweetCount: Int!
+}
 
 type Location {
-  bathroomCode: String
-  cityName: String!
-  dayAnnouncements: [Announcement!]!
-  id: ID!
-  isPrimary: Boolean!
-  latitude: Float!
-  longitude: Float!
-  moonPhase: Float!
-  solarCycles: [SolarCycle!]!
-  timeZone: String!
-  trafficCams: [TrafficCam!]!
-  weather: Weather!
-  widgets: WidgetCollection!
-  wifiName: String
-  wifiPassword: String
+    bathroomCode: String
+    cityName: String!
+    dayAnnouncements: [Announcement]!
+    id: ID!
+    isPrimary: Boolean!
+    latitude: Float!
+    longitude: Float!
+    moonPhase: Float!
+    solarCycles: [Solarcycle]!
+    timeZone: String!
+    trafficCams: [TrafficCam]!
+    weather: Weather!
+    widgets: WidgetCollection!
+    wifiName: String
+    wifiPassword: String
 }
 
-type MojoTweet {
-  insertedAt: DateTime!
-  interactions: TweetInteraction!
-  media: TweetMedia
-  status: String!
-  text: String!
-  user: TweetUser!
-}
-
-type Mutation {
-  testField: String!
+type Media {
+    images: [TwitterImage]
+    link: String
 }
 
 type NumbersWidget implements Widget {
-  durationSeconds: Int!
-
-  """
-  MojoTech slack/github events
-  """
-  events(createdAfter: String, type: EventSource): EventCollection!
-  id: Int!
-  locationId: Int!
-  name: String!
-  position: Int!
-  showWeather: Boolean
-  sidebarText: String
+    durationSeconds: Int!
+    "MojoTech slack/github events"
+    events(createdAfter: String, type: EventSource): EventCollection
+    id: Int!
+    locationId: String!
+    name: String!
+    position: Int!
+    showWeather: Boolean
+    sidebarText: String
 }
 
-type Query {
-  """
-  Employee events from bambooHR
-  """
-  employeeEvents: EmployeeEventCollection!
-
-  """
-  MojoTech slack/github events
-  """
-  events(createdAfter: String, type: EventSource): EventCollection!
-
-  """
-  Target location to receive updates
-  """
-  location(
-    """
-    City name of location
-    """
-    cityName: String!
-  ): Location!
-
-  """
-  Tweets from MojoTech
-  """
-  tweets: [MojoTweet!]!
+type RootQueryType {
+    "MojoTech slack/github events"
+    events(createdAfter: String, type: EventSource): EventCollection
+    location(cityName: String): Location
+    tweets: [Tweet]
 }
 
-type SolarCycle {
-  time: String!
-  type: String!
+type RootSubscriptionType {
+    "An announcement was published"
+    announcementPublished: Announcement!
+    "Updated SHA value"
+    deploymentSha: String!
+    "An event was published to the API"
+    eventPublished: Event!
+    "Latest weather data retrieved"
+    weatherPublished(latitude: Float!, longitude: Float!): Weather!
 }
 
-type Subscription {
-  """
-  An announcement was published
-  """
-  announcementPublished: Announcement!
-
-  """
-  Updated SHA value
-  """
-  deploymentSha: String!
-
-  """
-  An event was published to the API
-  """
-  eventPublished: Event!
-
-  """
-  Latest weather data retrieved
-  """
-  weatherPublished(latitude: Float!, longitude: Float!): Weather!
+type Solarcycle {
+    time: String!
+    type: String!
 }
 
 type TrafficCam {
-  feedFormat: String!
-  id: ID!
-  title: String!
-  url: String!
+    feedFormat: String!
+    id: ID!
+    title: String!
+    url: String!
 }
 
 type TrafficWidget implements Widget {
-  durationSeconds: Int!
-  id: Int!
-  locationId: Int!
-  name: String!
-  position: Int!
-  showWeather: Boolean
-  sidebarText: String
-  trafficCams: [TrafficCam!]!
+    durationSeconds: Int!
+    id: Int!
+    locationId: String!
+    name: String!
+    position: Int!
+    showWeather: Boolean
+    sidebarText: String
+    trafficCams: [TrafficCam]!
 }
 
-type TweetImageType {
-  id: Int!
-  mediaUrl: String!
+type Tweet {
+    insertedAt: DateTime!
+    interactions: Interaction!
+    media: Media
+    status: String!
+    text: String!
+    user: User!
 }
 
-type TweetInteraction {
-  favoriteCount: Int!
-  retweetCount: Int!
-}
-
-type TweetMedia {
-  images: [TweetImageType!]
-  link: String
-}
-
-type TweetUser {
-  avatar: String!
-  handle: String!
-  name: String!
+type TwitterImage {
+    id: Int!
+    mediaUrl: String!
 }
 
 type TwitterWidget implements Widget {
-  durationSeconds: Int!
-  id: Int!
-  locationId: Int!
-  name: String!
-  position: Int!
-  showWeather: Boolean
-  sidebarText: String
-
-  """
-  Tweets from MojoTech
-  """
-  tweets: [MojoTweet!]!
+    durationSeconds: Int!
+    id: Int!
+    locationId: String!
+    name: String!
+    position: Int!
+    showWeather: Boolean
+    sidebarText: String
+    "Tweets from MojoTech"
+    tweets: [Tweet]!
 }
 
-scalar UTCDateTime
-
-scalar UnixDateTime
+type User {
+    avatar: String!
+    handle: String!
+    name: String!
+}
 
 type Weather {
-  current: WeatherCurrentlyDetail!
-  daily: [WeatherDailyData!]!
-  hourly: [WeatherHourlyData!]!
-  lat: Float!
-  lon: Float!
-  minutely: [WeatherMinutelyData!]!
-  offset: Int!
-  timeZone: String!
+    current: WeatherCurrentlyDetail!
+    daily: [WeatherDailyData]!
+    hourly: [WeatherHourlyData]!
+    lat: Float!
+    lon: Float!
+    minutely: [WeatherMinutelyData]!
+    offset: Int!
+    timeZone: String!
 }
 
 type WeatherApparentTemperatureData {
-  day: Float!
-  eve: Float!
-  morn: Float!
-  night: Float!
+    day: Float!
+    eve: Float!
+    morn: Float!
+    night: Float!
 }
 
 type WeatherCurrentlyDetail {
-  clouds: Float!
-  dewPoint: Float!
-  feelsLike: Float!
-  humidity: Int!
-  nearestStormBearing: Int!
-  nearestStormDistance: Int!
-  pressure: Int!
-  temp: Float!
-  time: UnixDateTime!
-  uvi: Float!
-  visibility: Int!
-  weather: WeatherInfoData!
-  windDeg: Int!
-  windGust: Float
-  windSpeed: Float!
+    clouds: Float!
+    dewPoint: Float!
+    feelsLike: Float!
+    humidity: Int!
+    nearestStormBearing: Int!
+    nearestStormDistance: Int!
+    pressure: Int!
+    temp: Float!
+    time: UnixDateTime!
+    uvi: Float!
+    visibility: Int!
+    weather: WeatherInfoData!
+    windDeg: Int!
+    windGust: Float
+    windSpeed: Float!
 }
 
 type WeatherDailyData {
-  clouds: Int!
-  dewPoint: Int!
-  feelsLike: WeatherApparentTemperatureData!
-  humidity: Int!
-  precipProbability: Float!
-  pressure: Int!
-  rain: Float
-  sunrise: UnixDateTime!
-  sunset: UnixDateTime!
-  temp: WeatherTemperatureData!
-  time: UnixDateTime!
-  uvi: Float!
-  weather: WeatherInfoData!
-  windDeg: Int!
-  windSpeed: Float!
+    clouds: Int!
+    dewPoint: Int!
+    feelsLike: WeatherApparentTemperatureData!
+    humidity: Int!
+    precipProbability: Float!
+    pressure: Int!
+    rain: Float
+    sunrise: UnixDateTime!
+    sunset: UnixDateTime!
+    temp: WeatherTemperatureData!
+    time: UnixDateTime!
+    uvi: Float!
+    weather: WeatherInfoData!
+    windDeg: Int!
+    windSpeed: Float!
 }
 
 type WeatherHourlyData {
-  clouds: Int!
-  dewPoint: Float!
-  feelsLike: Float!
-  humidity: Int!
-  precipProbability: Float!
-  pressure: Int!
-  temp: Float!
-  time: UnixDateTime!
-  uvi: Float!
-  visibility: Int!
-  weather: WeatherInfoData!
-  windDeg: Int!
-  windGust: Float
-  windSpeed: Float!
+    clouds: Int!
+    dewPoint: Float!
+    feelsLike: Float!
+    humidity: Int!
+    precipProbability: Float!
+    pressure: Int!
+    temp: Float!
+    time: UnixDateTime!
+    uvi: Float!
+    visibility: Int!
+    weather: WeatherInfoData!
+    windDeg: Int!
+    windGust: Float
+    windSpeed: Float!
 }
 
 type WeatherInfoData {
-  description: String!
-  icon: IconIdToName!
-  id: Int!
-  main: String!
+    description: String!
+    icon: IconIdToName!
+    id: Int!
+    main: String!
 }
 
 type WeatherMinutelyData {
-  precipitation: Float!
-  time: UnixDateTime!
+    precipitation: Float!
+    time: UnixDateTime!
 }
 
 type WeatherTemperatureData {
-  day: Float!
-  eve: Float!
-  max: Float!
-  min: Float!
-  morn: Float!
-  night: Float!
+    day: Float!
+    eve: Float!
+    max: Float!
+    min: Float!
+    morn: Float!
+    night: Float!
 }
 
 type WeatherWidget implements Widget {
-  durationSeconds: Int!
-  id: Int!
-  locationId: Int!
-  name: String!
-  position: Int!
-  showWeather: Boolean
-  sidebarText: String
-
-  """
-  Weather response from Dark Sky
-  """
-  weather: Weather!
-}
-
-"""
-A single tab or panel of Helios
-"""
-interface Widget {
-  durationSeconds: Int!
-  id: Int!
-  locationId: Int!
-  name: String!
-  position: Int!
-  showWeather: Boolean
-  sidebarText: String
+    durationSeconds: Int!
+    id: Int!
+    locationId: String!
+    name: String!
+    position: Int!
+    showWeather: Boolean
+    sidebarText: String
+    "Weather response from Dark Sky"
+    weather: Weather!
 }
 
 type WidgetCollection {
-  byIdOrFirst(id: Int): Widget!
-  enabled: [Widget!]!
-  next(currentWidgetId: Int): Widget!
+    byIdOrFirst(id: Int): Widget!
+    enabled: [Widget]!
+    next(currentWidgetId: Int): Widget!
 }
+
+enum EventSource {
+    "Github commit"
+    githubCommit
+    "Github pull request"
+    githubPull
+    "Slack message"
+    slackMessage
+}
+
+"""
+
+The `DateTime` scalar type represents a date and time in the UTC
+timezone. The DateTime appears in a JSON response as an ISO8601 formatted
+string, including UTC timezone ("Z"). The parsed date and time string will
+be converted to UTC if there is an offset.
+"""
+scalar DateTime
+
+scalar IconIdToName
+
+scalar UnixDateTime

--- a/server-phoenix/lib/helios/event.ex
+++ b/server-phoenix/lib/helios/event.ex
@@ -57,6 +57,18 @@ defmodule Helios.Event do
     from(q in query, where: q.inserted_at < ^bow)
   end
 
+  def top_commits_by_author(query, top) do
+    from(q in query,
+      group_by: q.source_author,
+      select: %{
+        count: fragment("count(?) as count", q.source_author),
+        source_author: q.source_author
+      },
+      order_by: [desc: fragment("count")],
+      limit: ^top
+    )
+  end
+
   def count(query) do
     from(e in query, group_by: e.source, select: {e.source, count(e.source)})
   end

--- a/server-phoenix/lib/helios_web/schema/resolvers/event_collection.ex
+++ b/server-phoenix/lib/helios_web/schema/resolvers/event_collection.ex
@@ -21,10 +21,18 @@ defmodule HeliosWeb.Schema.Resolvers.EventCollection do
           Event
       end
 
+    {:ok, event_query}
+  end
+
+  def all(parent, _args, _info) do
+    {:ok, Repo.all(parent)}
+  end
+
+  def count(parent, _args, _info) do
     {:ok,
-     %{
-       all: Repo.all(event_query),
-       count: Event.count(event_query) |> Repo.all() |> Enum.into(%{})
-     }}
+     parent
+     |> Event.count()
+     |> Repo.all()
+     |> Enum.into(%{github_pull: 0, github_commit: 0, slack_message: 0})}
   end
 end

--- a/server-phoenix/lib/helios_web/schema/resolvers/event_collection.ex
+++ b/server-phoenix/lib/helios_web/schema/resolvers/event_collection.ex
@@ -24,7 +24,7 @@ defmodule HeliosWeb.Schema.Resolvers.EventCollection do
     {:ok,
      %{
        all: Repo.all(event_query),
-       count: Event.count(Event) |> Repo.all() |> Enum.into(%{})
+       count: Event.count(event_query) |> Repo.all() |> Enum.into(%{})
      }}
   end
 end

--- a/server-phoenix/lib/helios_web/schema/resolvers/event_collection.ex
+++ b/server-phoenix/lib/helios_web/schema/resolvers/event_collection.ex
@@ -28,6 +28,13 @@ defmodule HeliosWeb.Schema.Resolvers.EventCollection do
     {:ok, Repo.all(parent)}
   end
 
+  def by_author(parent, args, _info) do
+    {:ok,
+     parent
+     |> Event.top_commits_by_author(Map.get(args, :top, nil))
+     |> Repo.all()}
+  end
+
   def count(parent, _args, _info) do
     {:ok,
      parent

--- a/server-phoenix/lib/helios_web/schema/types/event.ex
+++ b/server-phoenix/lib/helios_web/schema/types/event.ex
@@ -14,5 +14,6 @@ defmodule HeliosWeb.Schema.Types.Event do
     field(:external_id, non_null(:string))
     field(:source, non_null(:event_source))
     field(:inserted_at, non_null(:datetime))
+    field(:source_author, non_null(:string))
   end
 end

--- a/server-phoenix/lib/helios_web/schema/types/event_collection.ex
+++ b/server-phoenix/lib/helios_web/schema/types/event_collection.ex
@@ -1,5 +1,6 @@
 defmodule HeliosWeb.Schema.Types.EventCollection do
   use Absinthe.Schema.Notation
+  alias HeliosWeb.Schema.Resolvers.EventCollection
 
   object :event_count do
     field(:github_pull, :integer)
@@ -8,7 +9,9 @@ defmodule HeliosWeb.Schema.Types.EventCollection do
   end
 
   object :event_collection do
-    field(:all, non_null(list_of(:event)))
+    field(:all, non_null(list_of(:event))) do
+      resolve(&EventCollection.all/3)
+    end
 
     field(:count, non_null(:event_count),
       default_value: %{
@@ -16,6 +19,8 @@ defmodule HeliosWeb.Schema.Types.EventCollection do
         github_commit: 0,
         slack_message: 0
       }
-    )
+    ) do
+      resolve(&EventCollection.count/3)
+    end
   end
 end

--- a/server-phoenix/lib/helios_web/schema/types/event_collection.ex
+++ b/server-phoenix/lib/helios_web/schema/types/event_collection.ex
@@ -8,9 +8,19 @@ defmodule HeliosWeb.Schema.Types.EventCollection do
     field(:slack_message, :integer)
   end
 
+  object :author_contribution do
+    field(:count, :integer)
+    field(:source_author, :string)
+  end
+
   object :event_collection do
     field(:all, non_null(list_of(:event))) do
       resolve(&EventCollection.all/3)
+    end
+
+    field(:by_author, list_of(:author_contribution)) do
+      arg(:top, :integer)
+      resolve(&EventCollection.by_author/3)
     end
 
     field(:count, non_null(:event_count),

--- a/server-phoenix/test/helios_web/schema/resolvers/event_collection_test.exs
+++ b/server-phoenix/test/helios_web/schema/resolvers/event_collection_test.exs
@@ -1,0 +1,50 @@
+defmodule HeliosWeb.Schema.Resolvers.EventCollectionTest do
+  use HeliosWeb.ConnCase, async: true
+  use ExUnit.Case
+  alias Helios.Event
+  alias Helios.Repo
+
+  test "getting authors by # of contributions, AUTHORS: top 2 of 3" do
+    insert_event(:github_pull, "279147430", "RVRX")
+    insert_event(:github_commit, "279147431", "RVRX")
+    insert_event(:github_commit, "279147432", "RVRX")
+    insert_event(:github_pull, "279147433", "RVRX")
+    insert_event(:slack_message, "279147434", "Cole Manning")
+    insert_event(:github_pull, "279147435", "Cole Manning")
+    insert_event(:slack_message, "279147436", "Cole Manning")
+    insert_event(:github_pull, "279147437", "another 2")
+    insert_event(:github_pull, "279147438", "another 2")
+
+    top_events = Event |> Event.top_commits_by_author(2) |> Repo.all()
+
+    assert top_events == [
+             %{count: 4, source_author: "RVRX"},
+             %{count: 3, source_author: "Cole Manning"}
+           ]
+  end
+
+  test "getting authors by # of contributions, AUTHORS: all" do
+    insert_event(:github_pull, "279147430", "RVRX")
+    insert_event(:github_commit, "279147432", "RVRX")
+    insert_event(:github_commit, "279147433", "RVRX")
+    insert_event(:slack_message, "279147434", "Cole Manning")
+    insert_event(:github_pull, "279147437", "another 2")
+    insert_event(:github_pull, "279147438", "another 2")
+
+    top_events = Event |> Event.top_commits_by_author(nil) |> Repo.all()
+
+    assert top_events == [
+             %{count: 3, source_author: "RVRX"},
+             %{count: 2, source_author: "another 2"},
+             %{count: 1, source_author: "Cole Manning"}
+           ]
+  end
+
+  defp insert_event(source, id, author) do
+    Repo.insert!(%Event{
+      source: source,
+      external_id: id,
+      source_author: author
+    })
+  end
+end


### PR DESCRIPTION
### ~~Note 1~~
_**Edit: See [comment below](https://github.com/mojotech/helios2/pull/403#issuecomment-1156899548)**_

~~The ticket originally called to bale able to run a GraphQL query of approximately the format:~~
```gql
query getTopAuthors {
  events(createdAfter: "2022-06-14T14:17:47Z") {
    byAuthor(top: 5) {
      author
      count
    }
  }
}
```
~~I've instead provided a query that is used like so:~~
```gql
query getTopAuthors {
  events(top: 5, createdAfter: "2022-06-14T14:17:47Z") {
    byAuthor {
      sourceAuthor
      count
    }
  }
}
```
~~The big difference being that the argument is passed to `events()` not to `byAuthor()`. This is due to difficulties with getting the argument in the [`event_collection` resolver](https://github.com/mojotech/helios2/blob/master/server-phoenix/lib/helios_web/schema/resolvers/event_collection.ex). I am unsure of the feasibility of doing it the planned way; any suggestions are welcome, but note that the current implementation does appear to be working fine, just maybe not set up as would be ideal.~~


### Note 2
the function `top_commits_by_author()` in `helios/event.ex` uses an [Ecto.Fragment](https://hexdocs.pm/ecto/Ecto.Query.html#module-fragments) (raw SQL statement), as it [wasn't possible](https://angelika.me/2016/09/10/how-to-order-by-the-result-of-select-count-in-ecto/#select-with-an-alias) to do the full statement with Ecto's query syntax. So if the DB Ecto points to is changed to something with non-standard sql different there is a [small?] chance that the statement will not work - but the unit test should flag this fine

### Note 3
`schema.graphql`. My IDE (IntelliJ) re-generated that file, so there are more non-meaningful changes (indentation, spacing...) than I'd like, but I am unsure how else to generate that file from the `schema.json`. If anyone knows a better way, that'd be appreciated.

### Testing
- Use the [graphiql](http://localhost:3000/graphiql) interface running on localhost with the above query.
- A unit test was added and can be run with the usual `mix test`