### PR TITLE
fix: esbuild backend port not grabbing assets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,3 +49,5 @@ spec/tmp
 vendor/assets/bower_components
 *.bowerrc
 bower.json
+
+server-phoenix/priv/static/index.html

--- a/app/javascript/packs/index.html
+++ b/app/javascript/packs/index.html
@@ -7,7 +7,7 @@
   </head>
 
   <body>
-    <link rel="stylesheet" type="text/css" href="./application.css" />
-    <script type="module" src="application.js"></script>
+    <link rel="stylesheet" type="text/css" href="./assets/application.css" />
+    <script type="module" src="assets/application.js"></script>
   </body>
 </html>

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -29,6 +29,7 @@ const buildConfig = {
   minify: true,
   outfile: 'server-phoenix/priv/static/assets/application.js',
   define,
+  publicPath: '/assets',
   metafile: true,
   external: ['node_modules'],
   loader: {
@@ -75,7 +76,7 @@ async function serve() {
     });
 
   liveServer.start({
-    root: 'server-phoenix/priv/static/assets',
+    root: 'server-phoenix/priv/static/',
     file: 'index.html',
     open: false,
     port: parseInt(frontendUrl.port, 10),

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "prettier:format": "prettier --write '{app/javascript/,__mocks__}/**/*.{js,jsx}' package.json webpack.config.js",
     "prettier:check": "prettier --check '{app/javascript/,__mocks__}/**/*.{js,jsx}' package.json webpack.config.js",
     "build": "node ./esbuild.config.js",
-    "serve": "cp app/javascript/packs/index.html server-phoenix/priv/static/assets && node ./esbuild.config.js --serve"
+    "serve": "cp app/javascript/packs/index.html server-phoenix/priv/static/ && node ./esbuild.config.js --serve"
   },
   "jest": {
     "verbose": true,


### PR DESCRIPTION
After testing with the backend port, @cbarber realized that there was an issue with Phoenix being able to grab assets. The fix to this is to put `publicPath: '/assets'` into our `esbuild.config.js` file and then restructure where our `index.html` file goes. The backend port should be successfully grabbing those assets now