### PR TITLE
Add REST API to create commit and PR events.

### DIFF
--- a/server-phoenix/lib/helios_web/controllers/events_api/events_api_controller.ex
+++ b/server-phoenix/lib/helios_web/controllers/events_api/events_api_controller.ex
@@ -1,0 +1,54 @@
+defmodule HeliosWeb.EventsAPI.EventsAPIController do
+  use HeliosWeb, :controller
+  alias Helios.{Repo, Event}
+
+  def handle(conn, params) do
+    cond do
+      params["version"] == "1" -> api_v1(conn, params)
+      true -> send_resp(conn, 404, "Not Found")
+    end
+  end
+
+  defp api_v1(conn, params) do
+    case params["event_type"] do
+      "github_commit" ->
+        post_event(
+          conn,
+          Event.commits(Event),
+          :github_commit,
+          params["event_id"],
+          params["author"]
+        )
+
+      _ ->
+        send_resp(conn, 400, "Bad Request")
+    end
+  end
+
+  defp post_event(conn, source_type_query, source, external_id, source_author) do
+    unless(
+      source_type_query
+      |> Event.with_external_id(external_id)
+      |> Repo.exists?()
+    ) do
+      Repo.insert!(%Event{
+        source: source,
+        external_id: external_id,
+        source_author: source_author
+      })
+      |> publish
+
+      send_resp(conn, 201, "Created")
+    else
+      send_resp(conn, 208, "Already Reported")
+    end
+  end
+
+  defp publish(event) do
+    Absinthe.Subscription.publish(
+      HeliosWeb.Endpoint,
+      event,
+      event_published: "all"
+    )
+  end
+end

--- a/server-phoenix/lib/helios_web/controllers/events_api/events_api_controller.ex
+++ b/server-phoenix/lib/helios_web/controllers/events_api/events_api_controller.ex
@@ -20,6 +20,15 @@ defmodule HeliosWeb.EventsAPI.EventsAPIController do
           params["author"]
         )
 
+      "github_pr" ->
+        post_event(
+          conn,
+          Event.pull_requests(Event),
+          :github_pull,
+          params["event_id"],
+          params["author"]
+        )
+
       _ ->
         send_resp(conn, 400, "Bad Request")
     end

--- a/server-phoenix/lib/helios_web/router.ex
+++ b/server-phoenix/lib/helios_web/router.ex
@@ -31,6 +31,10 @@ defmodule HeliosWeb.Router do
     post("/publish", PublishController, :handle)
   end
 
+  scope "/api/v:version/events", HeliosWeb.EventsAPI do
+    post("/", EventsAPIController, :handle)
+  end
+
   # Other scopes may use custom stacks.
   # scope "/api", HeliosWeb do
   #   pipe_through :api

--- a/server-phoenix/test/helios_web/controllers/events_api/events_api_controller_test.exs
+++ b/server-phoenix/test/helios_web/controllers/events_api/events_api_controller_test.exs
@@ -80,9 +80,80 @@ defmodule HeliosWeb.WebHooks.EventsAPIControllerTest do
     assert length(get_commits()) == 1
   end
 
+  test "POST new PR", %{conn: conn} do
+    conn =
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post(
+        Routes.events_api_path(conn, :handle, "1"),
+        %{
+          event_type: "github_pr",
+          author: "RVRX",
+          event_id: "726abde67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"
+        }
+      )
+
+    assert conn.status == 201
+    assert length(get_commits()) == 0
+    assert length(get_prs()) == 1
+  end
+
+  test "POST multiple commits (w/ duplicate IDs) and PRs", %{conn: conn} do
+    conn = conn |> put_req_header("content-type", "application/json")
+
+    conn
+    |> post(
+      Routes.events_api_path(conn, :handle, "1"),
+      %{
+        event_type: "github_commit",
+        author: "some1",
+        event_id: "a-common-hash"
+      }
+    )
+
+    conn
+    |> post(
+      Routes.events_api_path(conn, :handle, "1"),
+      %{
+        event_type: "github_commit",
+        author: "some1 else w/ same id",
+        event_id: "a-common-hash"
+      }
+    )
+
+    conn
+    |> post(
+      Routes.events_api_path(conn, :handle, "1"),
+      %{
+        event_type: "github_pr",
+        author: "RVRX",
+        event_id: "unique-hash"
+      }
+    )
+
+    conn
+    |> post(
+      Routes.events_api_path(conn, :handle, "1"),
+      %{
+        event_type: "github_pr",
+        author: "RVRX",
+        event_id: "another-unique-hash"
+      }
+    )
+
+    assert length(get_commits()) == 1
+    assert length(get_prs()) == 2
+  end
+
   defp get_commits() do
     Event
     |> Event.commits()
+    |> Repo.all()
+  end
+
+  defp get_prs() do
+    Event
+    |> Event.pull_requests()
     |> Repo.all()
   end
 end

--- a/server-phoenix/test/helios_web/controllers/events_api/events_api_controller_test.exs
+++ b/server-phoenix/test/helios_web/controllers/events_api/events_api_controller_test.exs
@@ -1,0 +1,88 @@
+defmodule HeliosWeb.WebHooks.EventsAPIControllerTest do
+  use HeliosWeb.ConnCase, async: true
+  use ExUnit.Case
+  alias Helios.Event
+  alias Helios.Repo
+
+  test "Proper status codes on different request", %{conn: conn} do
+    conn_1 =
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post(
+        Routes.events_api_path(conn, :handle, "1"),
+        %{
+          event_type: "foo_bar",
+          author: "RVRX",
+          event_id: "a26asde67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"
+        }
+      )
+
+    conn_2 =
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post(
+        Routes.events_api_path(conn, :handle, "2"),
+        %{
+          event_type: "foo_bar",
+          author: "RVRX",
+          event_id: "826asde67dff5eaf1h6ba5c57fc3c7d91ac0fd1c"
+        }
+      )
+
+    conn_3 =
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post(
+        Routes.events_api_path(conn, :handle, "1"),
+        %{
+          event_type: "github_commit",
+          author: "RVRX",
+          event_id: "x26asde67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"
+        }
+      )
+
+    conn_4 =
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post(
+        Routes.events_api_path(conn, :handle, "1"),
+        %{
+          event_type: "github_commit",
+          author: "RVRX",
+          event_id: "x26asde67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"
+        }
+      )
+
+    # Bad Request (Malformed)
+    assert conn_1.status == 400
+    # Not Found (No endpoint at URL)
+    assert conn_2.status == 404
+    # Created
+    assert conn_3.status == 201
+    # Already Reported (Duplicate event)
+    assert conn_4.status == 208
+  end
+
+  test "POST new commit", %{conn: conn} do
+    conn =
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post(
+        Routes.events_api_path(conn, :handle, "1"),
+        %{
+          event_type: "github_commit",
+          author: "RVRX",
+          event_id: "a26asde67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c"
+        }
+      )
+
+    assert conn.status == 201
+    assert length(get_commits()) == 1
+  end
+
+  defp get_commits() do
+    Event
+    |> Event.commits()
+    |> Repo.all()
+  end
+end


### PR DESCRIPTION
## Usage
#### **_OUTDATED, see [comment](https://github.com/mojotech/helios2/pull/409#issuecomment-1163466814)_**
**Endpoint**: `/api/v1/events/{id}`
Sending a POST request here with **body fields**:  `"event_type"` (one of either `"git_commit"` or `"git_pr"`) and `"author"` will add a new row to the DB.

### Example
```
POST localhost:4000/api/v1/events/2113728f27ae82c7b1a177c8d03f9e96e0adf246
```
```json
{
	"event_type": "git_commit",
	"author": "RVRX"
}
```
Will add:
| ... | source  | external_id | ... | source_author|
| -- | ------- | ------------| -- | --------------|
| ... | github_commit | 2113728f27ae82c7b1a177c8d03f9e96e0adf246 | ... | RVRX

## Notes
#### Note 1
The ticket for the PR end of this feature noted that:
> We'll need to come up with some unique id for a branch since this isn't internal to git. Something like sha256(git remote origin + git branch name) may work but would mean we'd need to duplicate the same process in the github webhook for PRs.

My interpretation of was that this would be dealt with on the client-side/whomever is sending the POST, but if we want to add the remote and branch name as fields, and calculate the ID off that, we could.

#### Note 2
Also my interpretation of a "REST API" was me googling it and deciding it sounded just like any other API I've used/created and building it as such. Wouldn't be surprised if I incorrectly implemented something on this front.