### PR TITLE
fix: Added '/' to Providence path for page_controller

### DIFF
--- a/server-phoenix/lib/helios_web/controllers/page_controller.ex
+++ b/server-phoenix/lib/helios_web/controllers/page_controller.ex
@@ -5,7 +5,7 @@ defmodule HeliosWeb.PageController do
     oauth_google_url = ElixirAuthGoogle.generate_oauth_url(conn)
     file = File.read!("priv/static/index.html")
 
-    in_path = conn.request_path in ["/Boulder", "Providence"]
+    in_path = conn.request_path in ["/Boulder", "/Providence"]
 
     if in_path do
       html(conn, file)


### PR DESCRIPTION
In #419, for some reason I completely forgot to add in '/' for the path of Providence in `page_controller.ex`. It should now be correctly redirecting from the Google Auth pages for the backend port.