### PR TITLE
fix: GenServer terminating from GQL subscriptions

### DIFF
--- a/app/javascript/components/get-weather-query.jsx
+++ b/app/javascript/components/get-weather-query.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import gql from 'graphql-tag';
 import { Query } from 'react-apollo';
-import { assocPath } from 'ramda';
 import { getSunriseSunsetLocation } from '@weather/sunrise-sunset';
 
 /* eslint-disable graphql/template-strings */
@@ -22,20 +21,6 @@ query getLocationWeather($cityName: String!) {
 ${WeatherFrag}
 `;
 
-/* eslint-enable graphql/template-strings */
-
-/* eslint-disable graphql/template-strings */
-const subscribeWeatherPublished = (WeatherFrag, queryName) => gql`
-  subscription onWeatherPublished($latitude: Float!, $longitude: Float!) {
-    weatherPublished(latitude: $latitude, longitude: $longitude) {
-      ...${queryName}
-    }
-  }
-
-  ${WeatherFrag}
-`;
-/* eslint-enable graphql/template-strings */
-
 export function WeatherQuery({
   Subscription,
   LoadingMessage,
@@ -52,7 +37,7 @@ export function WeatherQuery({
       onCompleted={startTimer}
       onError={startTimer}
     >
-      {({ loading, error, data, subscribeToMore }) => {
+      {({ loading, error, data }) => {
         if (loading) {
           return <LoadingMessage />;
         }
@@ -61,33 +46,7 @@ export function WeatherQuery({
           return <DisconnectedMessage />;
         }
 
-        return (
-          <Subscription
-            location={data.location}
-            subscribeToPublishedEvents={() =>
-              subscribeToMore({
-                document: subscribeWeatherPublished(WeatherFrag, queryName),
-                variables: {
-                  latitude: data.location.latitude,
-                  longitude: data.location.longitude,
-                },
-                updateQuery: (prev, { subscriptionData }) => {
-                  if (!subscriptionData.data) {
-                    return prev;
-                  }
-
-                  const { weatherPublished } = subscriptionData.data;
-
-                  return assocPath(
-                    ['location', 'weather'],
-                    weatherPublished,
-                    prev,
-                  );
-                },
-              })
-            }
-          />
-        );
+        return <Subscription location={data.location} />;
       }}
     </Query>
   );

--- a/app/javascript/components/weather-corner.jsx
+++ b/app/javascript/components/weather-corner.jsx
@@ -42,11 +42,8 @@ const SkyIconWrapper = styled.div`
   margin-bottom: 5px;
 `;
 
+// eslint-disable-next-line react/prefer-stateless-function
 class WeatherCorner extends React.Component {
-  componentDidMount() {
-    this.props.subscribeToPublishedEvents();
-  }
-
   render() {
     const { location } = this.props;
     const { weather } = location;
@@ -74,7 +71,6 @@ WeatherCorner.propTypes = {
       }).isRequired,
     }).isRequired,
   }).isRequired,
-  subscribeToPublishedEvents: PropTypes.func.isRequired,
 };
 
 const getWeatherQuery = ({ cityName }) => (

--- a/app/javascript/components/widgets/weather/panel.jsx
+++ b/app/javascript/components/widgets/weather/panel.jsx
@@ -72,10 +72,6 @@ const Notice = styled(GreySubText)`
 `;
 
 class SubscribedWeather extends React.Component {
-  componentDidMount() {
-    this.props.subscribeToPublishedEvents();
-  }
-
   shouldComponentUpdate(nextProps) {
     return this.props.location !== nextProps.location;
   }
@@ -106,7 +102,6 @@ SubscribedWeather.propTypes = {
   location: PropTypes.shape({
     weather: PropTypes.shape({}).isRequired,
   }).isRequired,
-  subscribeToPublishedEvents: PropTypes.func.isRequired,
 };
 
 const getWeatherQuery = ({ startTimer, cityName }) => (

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -2331,51 +2331,6 @@
                   "ofType": null
                 }
               }
-            },
-            {
-              "args": [
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "latitude",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Float",
-                      "ofType": null
-                    }
-                  }
-                },
-                {
-                  "defaultValue": null,
-                  "description": null,
-                  "name": "longitude",
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "Float",
-                      "ofType": null
-                    }
-                  }
-                }
-              ],
-              "deprecationReason": null,
-              "description": "Latest weather data retrieved",
-              "isDeprecated": false,
-              "name": "weatherPublished",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Weather",
-                  "ofType": null
-                }
-              }
             }
           ],
           "inputFields": null,

--- a/schema.graphql
+++ b/schema.graphql
@@ -127,8 +127,6 @@ type RootSubscriptionType {
     deploymentSha: String!
     "An event was published to the API"
     eventPublished: Event!
-    "Latest weather data retrieved"
-    weatherPublished(latitude: Float!, longitude: Float!): Weather!
 }
 
 type Solarcycle {

--- a/server-phoenix/lib/helios_web/AbsintheChannelDecorator.ex
+++ b/server-phoenix/lib/helios_web/AbsintheChannelDecorator.ex
@@ -90,7 +90,18 @@ defmodule HeliosWeb.AbsintheChannelDecorator do
   end
 
   def handle_in("unsubscribe", %{"subscriptionId" => doc_id}, socket) do
-    socket = run_unsubscribe(socket, "leave")
+    socket =
+      Socket.put_options(
+        socket,
+        context:
+          Map.merge(
+            socket.assigns.absinthe.opts[:context],
+            %{
+              "status" => "leave"
+            }
+          )
+      )
+
     Absinthe.Phoenix.Channel.handle_in("unsubscribe", %{"subscriptionId" => doc_id}, socket)
   end
 

--- a/server-phoenix/lib/helios_web/schema/types/sub.ex
+++ b/server-phoenix/lib/helios_web/schema/types/sub.ex
@@ -29,38 +29,6 @@ defmodule HeliosWeb.Schema.Types.Sub do
       end)
     end
 
-    field(:weather_published, non_null(:weather)) do
-      description("Latest weather data retrieved")
-      arg(:latitude, non_null(:float))
-      arg(:longitude, non_null(:float))
-
-      config(fn args,
-                %{
-                  context: %{
-                    "status" => status
-                  }
-                } ->
-        IO.puts("Channel Status")
-        IO.inspect(status)
-
-        if(status == "enter") do
-          IO.puts("subscribed")
-          add_args(args)
-        end
-
-        if(status == "leave" || status == "terminate") do
-          IO.puts("unsubscribed")
-          remove_args(args)
-        end
-
-        {:ok, topic: [args.latitude, args.longitude], context_id: "global"}
-      end)
-
-      resolve(fn event, _, _ ->
-        {:ok, event}
-      end)
-    end
-
     field(:announcement_published, non_null(:announcement),
       description: "An announcement was published"
     )


### PR DESCRIPTION
Most of the problem lies in `server-phoenix/lib/helios_web/AbsintheChannelDecorator.ex`, with some separate issues lying in `lib/helios_web/schema/types/sub.ex`

Here’s my current understanding of what is happening with the GenServer terminating from our subscriptions:

1. When we switch away from any widget, we run through all of our subscriptions due to our weather poller. For one of our subscriptions, the latitude and longitude values are not available (the weather subscription in this case). 
2. Originally, in the transition from Rails to Phoenix, we made `AbsintheChannelDecorator.ex` to try and get topics with their arguments, as Rails had this capability but Phoenix did not. So, the intention was for these subscriptions to be unsubscribed on page close events, but they are being executed on widget transitions as well because of the React components. So, on the switch of the widgets, we try to unsubscribe, specifically at Line 92 where we have `handle_in(“unsubscribe”, …)`
3. When we unsubscribe, we redefine our socket in `run_unsubscribe`, and in doing so we execute `run(query, config[:schema], config[:pipeline], opts)`
4. `run(document, schema, pipeline, options)` goes through `Absinthe.Pipeline.run`
5. This query returns null since the values are not available for latitude and longitude (seen in `app/javascript/components/get-weather-query.jsx` starting at Line 65)
6. Because we expect values, we get an error from running `Absinthe.Pipeline.run`, but this is accompanied with an `:ok` atom (there are some problems here in our `run_unsubscribe` function where we are going to potentially get an empty map from our variables on line 34 in `AbsintheChannelDecorator.ex`)
7. Our socket has been redefined, containing the body of `{:ok, %{errors: …}`, and then inside of our `handle_in` function, we call `Absinthe.Phoenix.Channel.handle_in(“unsubscribe”…)`
8. Because of the errors contained inside of our redefined socket, we never enter the config section of `sub.ex` for our field `:weather_published`, which removes the arguments from our subscription
9. Inside of `AbsintheChannelDecorator.ex`, after we call `handle_in` with our unsubscribe event and new socket, we call `terminate(reason, socket)` at Line 14 and we terminate the GenServer because of the errors passed down from earlier (null values for latitude and longitude)

**Fix:** 
Now, when compared to how the subscriptions are handled when we are subscribing, we can look to the other `handle_in` function. Here, we just redefine the socket, define the “status” to be “enter” (Line 81), and then call `Absinthe.Phoenix.Channel.handle_in(…)`. This works, and if you take a look at the backend log, we can always see the subscriptions being entered (e.g. “Channel Status”, “enter”), but we never see subscriptions being left (logic defined in `sub.ex`). 

As a test to fix the bug, I put in similar logic from the other `handle_in` function, and instead of running `run_unsubscribe`, we redefine our socket to simply have the “status” of “leave”. After doing this, our call to `Absinthe.Phoenix.Channel.handle_in` with “unsubscribe” works perfectly, and all of the GenServer related errors are resolved and don’t show up anymore. 

To further cement this fix, we can opt for the Cron job's data (in `config.exs`) with the weather poller worker instead of relying on our GraphQL subscription - we then remove our `subscribeWeatherPublished` component in React, the `subscribeToPublishedEvents()` function, and the `:weather_published` subscription in `sub.ex`. Now, the weather poller should be our source for weather data (from the Cron job running every 5th minute), and our page should be working properly without the GenServer crashing.