### PR TITLE
Fix torch navbar links

### DIFF
--- a/server-phoenix/lib/helios_web/templates/layout/torch.html.heex
+++ b/server-phoenix/lib/helios_web/templates/layout/torch.html.heex
@@ -29,14 +29,14 @@
           </div>
           <nav class="torch-nav">
             <!-- nav links here -->
-            <a href="events">Events</a>
-            <a href="daily_event_summaries">Daily Event Summaries</a>
-            <a href="developer_users">Developer Users</a>
-            <a href="locations">Locations</a>
-            <a href="users">Users</a>
-            <a href="announcements">Announcements</a>
-            <a href="widgets">Widgets</a>
-            <a href="traffic_cams">Traffic Cams</a>
+            <a href="/admin/events">Events</a>
+            <a href="/admin/daily_event_summaries">Daily Event Summaries</a>
+            <a href="/admin/developer_users">Developer Users</a>
+            <a href="/admin/locations">Locations</a>
+            <a href="/admin/users">Users</a>
+            <a href="/admin/announcements">Announcements</a>
+            <a href="/admin/widgets">Widgets</a>
+            <a href="/admin/traffic_cams">Traffic Cams</a>
           </nav>
         </div>
       </section>


### PR DESCRIPTION
Makes the torch navbar links absolute paths to prevent broken links when in a torch sub-page
