### PR TITLE
Wo/display slack images

### DIFF
--- a/app/javascript/components/widget-display.jsx
+++ b/app/javascript/components/widget-display.jsx
@@ -13,6 +13,7 @@ import Twitter from '@widgets/twitter';
 import Numbers from '@widgets/numbers';
 import Weather from '@widgets/weather';
 import Traffic from '@widgets/traffic';
+import Feed from '@widgets/feed';
 import Events from '@widgets/events';
 import withFragment from './hocs/with-fragment';
 
@@ -33,6 +34,7 @@ const widgetElements = {
   Numbers,
   Traffic,
   Events,
+  Feed,
 };
 
 export function WidgetDisplay({

--- a/app/javascript/components/widgets/feed/index.jsx
+++ b/app/javascript/components/widgets/feed/index.jsx
@@ -1,0 +1,5 @@
+import Panel from '@root/app/javascript/components/widgets/feed/panel';
+
+export default {
+  Panel,
+};

--- a/app/javascript/components/widgets/feed/panel.jsx
+++ b/app/javascript/components/widgets/feed/panel.jsx
@@ -1,0 +1,86 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { WhiteSubTitle, WhiteTitleLarge } from '@components/typography';
+import gql from 'graphql-tag';
+import { Query } from 'react-apollo';
+import { LoadingMessage, DisconnectedMessage } from '@messages/message';
+import { Carousel } from 'react-responsive-carousel';
+import 'react-responsive-carousel/lib/styles/carousel.css';
+
+const Title = styled.div`
+  margin-bottom: 50px;
+  margin-left: 50px;
+  width: 45vw;
+`;
+
+const getMojoDoggos = gql`
+  query getDoggos {
+    feeds {
+      uuid
+    }
+  }
+`;
+
+const PanelWrapper = styled.div`
+  overflow: hidden;
+  height: 90%;
+`;
+
+function Feed({ feeds }) {
+  return (
+    <PanelWrapper>
+      <Title>
+        <WhiteTitleLarge>Images at MojoTech</WhiteTitleLarge>
+        <WhiteSubTitle>#mojodoggos</WhiteSubTitle>
+      </Title>
+      <Carousel
+        width="60%"
+        autoPlay
+        showThumbs={false}
+        interval={3000}
+        showStatus={false}
+      >
+        {feeds.map(({ uuid }) => (
+          <img alt="dog" src={`/images/${uuid}`} />
+        ))}
+      </Carousel>
+    </PanelWrapper>
+  );
+}
+
+Feed.propTypes = {
+  feeds: PropTypes.arrayOf(
+    PropTypes.shape({
+      uuid: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+};
+
+function Feeder({ startTimer }) {
+  useEffect(() => {
+    startTimer();
+  }, []);
+
+  return (
+    <Query query={getMojoDoggos} onCompleted={startTimer} onError={startTimer}>
+      {({ loading, error, data }) => {
+        if (loading) {
+          return <LoadingMessage />;
+        }
+
+        if (error) {
+          // eslint-disable-next-line
+          console.error('error');
+          return <DisconnectedMessage />;
+        }
+
+        return <Feed feeds={data.feeds} />;
+      }}
+    </Query>
+  );
+}
+Feeder.propTypes = {
+  startTimer: PropTypes.func.isRequired,
+};
+export default Feeder;

--- a/app/javascript/schema.json
+++ b/app/javascript/schema.json
@@ -1477,6 +1477,206 @@
           "possibleTypes": null
         },
         {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "author",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "source",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "uuid",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "Feed",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "durationSeconds",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "feeds from MojoTech",
+              "isDeprecated": false,
+              "name": "feeds",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Feed",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "locationId",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "position",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "showWeather",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "sidebarText",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Widget",
+              "ofType": null
+            }
+          ],
+          "kind": "OBJECT",
+          "name": "FeedWidget",
+          "possibleTypes": null
+        },
+        {
           "description": "The `Float` scalar type represents signed double-precision fractional\nvalues as specified by\n[IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
           "enumValues": null,
           "fields": null,
@@ -2179,6 +2379,22 @@
                 "kind": "OBJECT",
                 "name": "EventCollection",
                 "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "feeds",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Feed",
+                  "ofType": null
+                }
               }
             },
             {
@@ -4341,6 +4557,11 @@
             {
               "kind": "OBJECT",
               "name": "EventsWidget",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "FeedWidget",
               "ofType": null
             },
             {

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -136,6 +136,11 @@ async function serve() {
         port: backendUrl.port,
         route: '/events',
       }),
+      proxy({
+        ...url.parse(`${frontendUrl}/images`),
+        port: backendUrl.port,
+        route: '/images',
+      }),
     ],
     logLevel: 0,
   });

--- a/server-phoenix/lib/helios/feed.ex
+++ b/server-phoenix/lib/helios/feed.ex
@@ -10,4 +10,12 @@ defmodule Helios.Feed do
 
     timestamps()
   end
+
+  def top_images(query \\ __MODULE__) do
+    from(q in query,
+      select: %{"uuid" => q.uuid},
+      limit: 6,
+      order_by: fragment("RANDOM()")
+    )
+  end
 end

--- a/server-phoenix/lib/helios_web/controllers/signed_image_controller.ex
+++ b/server-phoenix/lib/helios_web/controllers/signed_image_controller.ex
@@ -1,0 +1,14 @@
+defmodule HeliosWeb.SignedImageController do
+  use HeliosWeb, :controller
+  require Logger
+  require JSON
+
+  defp upload_bearer_token,
+    do: Application.get_env(:helios, HeliosWeb.Endpoint)[:upload_bearer_token]
+
+  def handle(conn, params) do
+    signed_url = Helios.Avatar.url({params["uuid"], ""}, :thumb, signed: true)
+
+    redirect(conn, external: signed_url)
+  end
+end

--- a/server-phoenix/lib/helios_web/router.ex
+++ b/server-phoenix/lib/helios_web/router.ex
@@ -57,6 +57,7 @@ defmodule HeliosWeb.Router do
   scope "/", HeliosWeb do
     pipe_through [:browser]
 
+    get "/images/:uuid", SignedImageController, :handle
     delete "/admins/log_out", AdminSessionController, :delete
     get "/admins/confirm", AdminConfirmationController, :new
     post "/admins/confirm", AdminConfirmationController, :create
@@ -77,7 +78,6 @@ defmodule HeliosWeb.Router do
   scope "/web_hooks", HeliosWeb.WebHooks do
     post("/github", GithubController, :handle)
     post("/slack", SlackController, :handle)
-
     post("/publish", PublishController, :handle)
   end
 

--- a/server-phoenix/lib/helios_web/schema.ex
+++ b/server-phoenix/lib/helios_web/schema.ex
@@ -45,11 +45,13 @@ defmodule HeliosWeb.Schema do
   import_types(HeliosWeb.Schema.Queries.Location)
   import_types(HeliosWeb.Schema.Queries.Tweet)
   import_types(HeliosWeb.Schema.Queries.EventCollection)
+  import_types(HeliosWeb.Schema.Queries.Feed)
 
   query do
     import_fields(:location_queries)
     import_fields(:tweet_queries)
     import_fields(:event_collection_queries)
+    import_fields(:feed_queries)
   end
 
   subscription do

--- a/server-phoenix/lib/helios_web/schema/queries/feed.ex
+++ b/server-phoenix/lib/helios_web/schema/queries/feed.ex
@@ -1,0 +1,11 @@
+defmodule HeliosWeb.Schema.Queries.Feed do
+  use Absinthe.Schema.Notation
+
+  alias HeliosWeb.Schema.Resolvers.Feed
+
+  object :feed_queries do
+    field :feeds, list_of(:feed) do
+      resolve(&Feed.feeds/3)
+    end
+  end
+end

--- a/server-phoenix/lib/helios_web/schema/resolvers/feed.ex
+++ b/server-phoenix/lib/helios_web/schema/resolvers/feed.ex
@@ -1,0 +1,13 @@
+defmodule HeliosWeb.Schema.Resolvers.Feed do
+  alias Helios.{Repo, Feed}
+  require Logger
+
+  def feeds(_parent, _args, _info) do
+    feed_query =
+      Feed
+      |> Feed.top_images()
+      |> Repo.all()
+
+    {:ok, feed_query}
+  end
+end

--- a/server-phoenix/lib/helios_web/schema/types/widget.ex
+++ b/server-phoenix/lib/helios_web/schema/types/widget.ex
@@ -9,6 +9,7 @@ defmodule HeliosWeb.Schema.Types.Widget do
       "Guests" => :guests_widget,
       "Weather" => :weather_widget,
       "Twitter" => :twitter_widget,
+      "Feed" => :feed_widget,
       "Numbers" => :numbers_widget,
       "Traffic" => :traffic_widget,
       "Events" => :events_widget
@@ -84,6 +85,23 @@ defmodule HeliosWeb.Schema.Types.Widget do
     field :tweets, non_null(list_of(:tweet)) do
       description("Tweets from MojoTech")
       resolve(&Widget.tweets/3)
+    end
+  end
+
+  object :feed_widget do
+    interface(:widget)
+
+    field(:id, non_null(:integer))
+    field(:name, non_null(:string))
+    field(:duration_seconds, non_null(:integer))
+    field(:position, non_null(:integer))
+    field(:sidebar_text, :string)
+    field(:show_weather, :boolean)
+    field(:location_id, non_null(:string))
+
+    field :feeds, non_null(list_of(:feed)) do
+      description("feeds from MojoTech")
+      resolve(&Widget.feeds/3)
     end
   end
 

--- a/server-phoenix/priv/repo/seeds.exs
+++ b/server-phoenix/priv/repo/seeds.exs
@@ -65,7 +65,7 @@ Repo.all(Location)
   })
 
   EctoHelpers.find_or_initialize_by(Widget, [name: "Numbers", location_id: location.id], %Widget{
-    enabled: true,
+    enabled: false,
     duration_seconds: 20,
     position: 3,
     sidebar_text: "MojoTech by the Numbers",
@@ -73,7 +73,7 @@ Repo.all(Location)
   })
 
   EctoHelpers.find_or_initialize_by(Widget, [name: "Traffic", location_id: location.id], %Widget{
-    enabled: true,
+    enabled: false,
     duration_seconds: 20,
     position: 4,
     sidebar_text: "Traffic",
@@ -83,10 +83,18 @@ Repo.all(Location)
   })
 
   EctoHelpers.find_or_initialize_by(Widget, [name: "Events", location_id: location.id], %Widget{
-    enabled: true,
+    enabled: false,
     duration_seconds: 20,
     position: 5,
     sidebar_text: "Events at MojoTech",
+    show_weather: true
+  })
+
+  EctoHelpers.find_or_initialize_by(Widget, [name: "Feed", location_id: location.id], %Widget{
+    enabled: true,
+    duration_seconds: 20,
+    position: 6,
+    sidebar_text: "Feed",
     show_weather: true
   })
 end)


### PR DESCRIPTION
this PR creates a feed widget and adds it to helios, displaying uploaded images from a specific channel

https://user-images.githubusercontent.com/39812727/184175836-37a60ee7-f5fe-44ff-b2f3-00ced3612402.mp4

https://www.pivotaltracker.com/story/show/182406640

This feature came from the ticket above. The main functionality works by sending an interactive message from a slack bot to a user who just sent an image in slack, asking if they'd like it uploaded to helios. If they click yes, the image is added to the feeds table and a unique id is generated.

The image is downloaded and then uploaded to the S3 bucket with the same unique id that was created upon insertion into the feeds table. 

The feed widget displays these images by making a get request to the backend which returns a redirect to the signed url from the S3 bucket. 

Note for local development, the seeds.exs file must be run to add the feed widget. 