### PR TITLE
fix: typo in prettier

### DIFF
--- a/app/javascript/components/get-weather-query.jsx
+++ b/app/javascript/components/get-weather-query.jsx
@@ -42,7 +42,7 @@ export function WeatherQuery({
           return <LoadingMessage />;
         }
         if (error) {
-        console.error(error); // eslint-disable-line
+          console.error(error); // eslint-disable-line
           return <DisconnectedMessage />;
         }
 

--- a/app/javascript/components/widgets/guests/panel.jsx
+++ b/app/javascript/components/widgets/guests/panel.jsx
@@ -114,7 +114,7 @@ function Guests({ cityName }) {
       {({ loading, error, data, subscribeToMore }) => {
         if (error) {
           // eslint-disable-next-line
-        console.error(error);
+          console.error(error);
           return <DisconnectedMessage />;
         }
 

--- a/app/javascript/components/widgets/numbers/panel.jsx
+++ b/app/javascript/components/widgets/numbers/panel.jsx
@@ -149,7 +149,7 @@ function Numbers({ startTimer }) {
 
         if (error) {
           // eslint-disable-next-line
-        console.error(error);
+          console.error(error);
           return <DisconnectedMessage />;
         }
 

--- a/app/javascript/components/widgets/twitter/panel.jsx
+++ b/app/javascript/components/widgets/twitter/panel.jsx
@@ -99,7 +99,7 @@ function TwitterController({ startTimer }) {
 
         if (error) {
           // eslint-disable-next-line
-        console.error(error);
+          console.error(error);
           return <DisconnectedMessage />;
         }
 

--- a/app/javascript/components/widgets/weather/weather-effect.jsx
+++ b/app/javascript/components/widgets/weather/weather-effect.jsx
@@ -361,29 +361,29 @@ Cloud.propTypes = {
 
 /* eslint-disable prettier/prettier */
 function RainLight() {
-  return <Rain duration={0.6} variance={0.4} count={10} />
+  return <Rain duration={0.6} variance={0.4} count={10} />;
 }
 function RainModerate() {
-  return <Rain duration={0.5} variance={0.3} count={20} />
+  return <Rain duration={0.5} variance={0.3} count={20} />;
 }
 function RainHeavy() {
-  return <Rain duration={0.5} variance={0.2} count={35} angle={15} />
+  return <Rain duration={0.5} variance={0.2} count={35} angle={15} />;
 }
 function RainIntense() {
-  return <Rain duration={0.4} variance={0.1} count={40} angle={30} />
+  return <Rain duration={0.4} variance={0.1} count={40} angle={30} />;
 }
 function RainExtreme() {
-  return <Rain duration={0.5} variance={0.1} count={60} angle={45} />
+  return <Rain duration={0.5} variance={0.1} count={60} angle={45} />;
 }
 
 function DrizzleLight() {
-  return <Drizzle duration={1.8} variance={0.5} count={30} />
+  return <Drizzle duration={1.8} variance={0.5} count={30} />;
 }
 function DrizzleModerate() {
-  return <Drizzle duration={1.5} variance={0.5} count={45} />
+  return <Drizzle duration={1.5} variance={0.5} count={45} />;
 }
 function DrizzleHeavy() {
-  return <Drizzle duration={1.2} variance={0.4} count={60} />
+  return <Drizzle duration={1.2} variance={0.4} count={60} />;
 }
 
 const weatherIdMap = {

--- a/package.json
+++ b/package.json
@@ -127,8 +127,8 @@
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "relative-to-alias": "jscodeshift --extensions jsx -t ./config/transforms/relative_to_alias_path.js ./ ",
-    "prettier:format": "prettier --write '{app/javascript/,__mocks__}/**/*.{js,jsx}' package.json",
-    "prettier:check": "prettier --check '{app/javascript/,__mocks__}/**/*.{js,jsx}' package.json",
+    "prettier:format": "prettier --write '{app/javascript,__mocks__}/**/*.{js,jsx}' package.json",
+    "prettier:check": "prettier --check '{app/javascript,__mocks__}/**/*.{js,jsx}' package.json",
     "build": "cp app/javascript/packs/index.html server-phoenix/priv/static/ && node ./esbuild.config.js",
     "serve": "cp app/javascript/packs/index.html server-phoenix/priv/static/ && node ./esbuild.config.js --serve"
   },


### PR DESCRIPTION
A typo in prettier was causing it not to be run. Fixed the typo and called prettier:format to update files where prettier had not been run.