### PR TITLE
adding Event alias

### DIFF
--- a/server-phoenix/lib/helios_web/controllers/web_hooks/publish_controller.ex
+++ b/server-phoenix/lib/helios_web/controllers/web_hooks/publish_controller.ex
@@ -1,5 +1,6 @@
 defmodule HeliosWeb.WebHooks.PublishController do
   use HeliosWeb, :controller
+  alias Helios.{Events.Event}
 
   def handle(conn, params) do
     event =


### PR DESCRIPTION
publish_controller (used in simulate.ex for local development) didn't have Event alias and was throwing errors for that reason